### PR TITLE
Fix/slop-25/refactor-fest-route

### DIFF
--- a/src/graphql/get-discussions.js
+++ b/src/graphql/get-discussions.js
@@ -3,6 +3,7 @@ import { gql } from "@apollo/client";
 export const GET_DISCUSSIONS = gql`
   query Fest($where: FestWhereUniqueInput!) {
     fest(where: $where) {
+      id
       festNotes {
         content
         createdAt

--- a/src/graphql/get-fest.js
+++ b/src/graphql/get-fest.js
@@ -3,6 +3,7 @@ import { gql } from "@apollo/client";
 export const GET_FEST = gql`
   query GetFest($where: FestWhereUniqueInput!) {
     fest(where: $where) {
+      id
       attendees {
         id
         username

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -24,7 +24,7 @@ import {
   SearchRoute,
   SoundsRoute,
 } from "./routes";
-import { FestRoute } from "./routes/fest-route";
+import { FestDiscussion, FestRoute } from "./routes/fest-route";
 import { CurrentUserContextProvider, ModalContextProvider } from "./store";
 
 const httpLink = createHttpLink({
@@ -131,7 +131,7 @@ ReactDOM.createRoot(document.getElementById("root")).render(
                 path="/fests/:festId/discussion"
                 element={
                   <ProtectedRoute>
-                    <FestRoute />
+                    <FestDiscussion />
                   </ProtectedRoute>
                 }
               />

--- a/src/routes/fest-route/fest-discussion.jsx
+++ b/src/routes/fest-route/fest-discussion.jsx
@@ -1,20 +1,36 @@
-import { useMutation } from "@apollo/client";
+import { useMutation, useQuery } from "@apollo/client";
 import { useContext, useState } from "react";
-import { DiscussionCard } from "../../components";
-import { Button } from "../../components/button/index";
-import { CREATE_DISCUSSION, GET_DISCUSSIONS } from "../../graphql/index.js";
+import { useParams } from "react-router";
+import { Button, DiscussionCard, Header, Loading } from "../../components";
+import {
+  CREATE_DISCUSSION,
+  GET_DISCUSSIONS,
+  GET_FEST,
+} from "../../graphql/index.js";
 import { CurrentUserContext } from "../../store/current-user-context.js";
+import { FestHeader, FestSidebar } from "../fest-route";
 
-export const FestDiscussion = ({ discussionQuery, festQuery, festId }) => {
+export const FestDiscussion = ({}) => {
   const [discussionContent, setDiscussionContent] = useState("");
   const { currentUser } = useContext(CurrentUserContext);
   const userId = currentUser?.id;
+  const festId = useParams().festId;
   const isValid = discussionContent.length !== 0 ? true : false;
+
+  // Fest Query to pull fests from server
+  const festQuery = useQuery(GET_FEST, {
+    variables: { where: { id: festId } },
+  });
 
   // Create an array of all attendees to later check if the current user is in list
   const attendeesList = festQuery?.data?.fest?.attendees?.map(
     (person) => person?.id
   );
+
+  // Discussion Query to pull all discussions from server
+  const discussionQuery = useQuery(GET_DISCUSSIONS, {
+    variables: { where: { id: festId } },
+  });
 
   // Mutation to add discussion to server, and refetch the queries
   const [
@@ -41,62 +57,83 @@ export const FestDiscussion = ({ discussionQuery, festQuery, festId }) => {
     else setDiscussionContent(""); // reset discussionContent to blank
   };
 
+  if (discussionIsLoading) {
+    return <Loading />;
+  }
+
   return (
-    <div className="w-3/5 sm:w-1/2">
-      <div>
-        {/* If discussionQuery is loading or the length is 0, show "no notes here yet" */}
-        {!discussionQuery?.loading &&
-        discussionQuery &&
-        discussionQuery?.data?.fest?.festNotes?.length === 0 ? (
-          <h2 className="font-arial text-lg/4 m-auto text-center pb-96">
-            No notes here yet
-          </h2>
-        ) : (
-          // otherwise show the posts coming from the backend
-          <div className="h-96 overflow-y-scroll">
-            {discussionQuery?.data?.fest?.festNotes
-              .map((discussion) => (
-                // Map each item onto the DiscussionCard template
-                <DiscussionCard
-                  discussion={discussion}
-                  key={discussion?.id ?? discussion._id}
-                />
-              ))
-              .sort((a, b) => {
-                // sort posts based on their time elapsed in milliseconds since 1970, placing more recent discussions at bottom
-                return (
-                  Date.parse(new Date(a.props.discussion.createdAt)) -
-                  Date.parse(new Date(b.props.discussion.createdAt))
-                );
-              })}
-          </div>
+    <>
+      <Header>
+        <Header.Logo />
+        <Header.NavLinks />
+        <Header.Profile />
+      </Header>
+      <div className="max-w-[1200px] my-0 mx-auto box-border">
+        {!festQuery.loading && festQuery?.data?.fest && (
+          <FestHeader fest={festQuery.data.fest} />
         )}
-      </div>
-      {/* Check for the userId is in attendees list (only attendees can write comments); if not hide option to write discussion */}
-      {attendeesList?.includes(userId) && (
-        <div className="flex gap-x-10 mt-6">
-          <textarea
-            className="w-5/6 h-11 max-h-20 min-h-11 text-left outline-0 border text-dark px-2.5 py-2 border-black/[0.5]"
-            placeholder="Type your message here"
-            type="text"
-            name="discussion-content"
-            value={discussionContent}
-            onChange={(evt) => setDiscussionContent(evt.target.value)}
-          ></textarea>
-          <div className="">
-            <Button
-              disabled={!isValid} // prevent users from being able to submit blank posts
-              variant="secondary"
-              type="button"
-              size="sm"
-              className="px-6 h-11 max-h-11"
-              onClick={handleDiscussionSubmit}
-            >
-              Send
-            </Button>
+        <div className="flex gap-x-24">
+          {!festQuery.loading && festQuery?.data?.fest && (
+            <FestSidebar festQuery={festQuery} />
+          )}
+          <div className="w-3/5 sm:w-1/2">
+            <div>
+              {/* If discussionQuery is loading or the length is 0, show "no notes here yet" */}
+              {!discussionQuery?.loading &&
+              discussionQuery &&
+              discussionQuery?.data?.fest?.festNotes?.length === 0 ? (
+                <h2 className="font-arial text-lg/4 m-auto text-center pb-96">
+                  No notes here yet
+                </h2>
+              ) : (
+                // otherwise show the posts coming from the backend
+                <div className="h-96 overflow-y-scroll">
+                  {discussionQuery?.data?.fest?.festNotes
+                    .map((discussion) => (
+                      // Map each item onto the DiscussionCard template
+                      <DiscussionCard
+                        discussion={discussion}
+                        key={discussion?.id ?? discussion._id}
+                      />
+                    ))
+                    .sort((a, b) => {
+                      // sort posts based on their time elapsed in milliseconds since 1970, placing more recent discussions at bottom
+                      return (
+                        Date.parse(new Date(a.props.discussion.createdAt)) -
+                        Date.parse(new Date(b.props.discussion.createdAt))
+                      );
+                    })}
+                </div>
+              )}
+            </div>
+            {/* Check for the userId is in attendees list (only attendees can write comments); if not hide option to write discussion */}
+            {attendeesList?.includes(userId) && (
+              <div className="flex gap-x-10 mt-6">
+                <textarea
+                  className="w-5/6 h-11 max-h-20 min-h-11 text-left outline-0 border text-dark px-2.5 py-2 border-black/[0.5]"
+                  placeholder="Type your message here"
+                  type="text"
+                  name="discussion-content"
+                  value={discussionContent}
+                  onChange={(evt) => setDiscussionContent(evt.target.value)}
+                ></textarea>
+                <div className="">
+                  <Button
+                    disabled={!isValid} // prevent users from being able to submit blank posts
+                    variant="secondary"
+                    type="button"
+                    size="sm"
+                    className="px-6 h-11 max-h-11"
+                    onClick={handleDiscussionSubmit}
+                  >
+                    Send
+                  </Button>
+                </div>
+              </div>
+            )}
           </div>
         </div>
-      )}
-    </div>
+      </div>
+    </>
   );
 };

--- a/src/routes/fest-route/fest-route.jsx
+++ b/src/routes/fest-route/fest-route.jsx
@@ -92,7 +92,7 @@ export const FestRoute = () => {
           {!festQuery.loading && festQuery?.data?.fest && (
             <FestSidebar festQuery={festQuery} />
           )}
-          <div className="flex flex-col gap-y-8">
+          <div className="w-full flex flex-col gap-y-8">
             <div className="flex justify-between items-center">
               {!festQuery.loading && movies && movies.length > 0 && (
                 <h2 className="font-arial text-lg/4 font-bold">

--- a/src/routes/fest-route/fest-route.jsx
+++ b/src/routes/fest-route/fest-route.jsx
@@ -1,65 +1,23 @@
 import { useMutation, useQuery } from "@apollo/client";
-import { useContext, useEffect, useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import { useParams } from "react-router";
-import { useLocation, useNavigate } from "react-router-dom";
 import { Button, Header, Loading, MovieCardList } from "../../components";
-import {
-  DELETE_FEST,
-  GET_DISCUSSIONS,
-  GET_FEST,
-  GET_MOVIES,
-  GET_USER_FESTS,
-  UPDATE_FEST,
-} from "../../graphql/";
+import { GET_FEST, GET_MOVIES, UPDATE_FEST } from "../../graphql/";
 import magGlassDark from "../../images/mag-glass-black.svg";
 import { useModals } from "../../store";
-import { CurrentUserContext } from "../../store/current-user-context.js";
-import {
-  FestDiscussion,
-  FestHeader,
-  FestModal,
-  FestSidebar,
-} from "../fest-route";
+import { FestHeader, FestModal, FestSidebar } from "../fest-route";
 
 export const FestRoute = () => {
-  const location = useLocation();
-  const navigate = useNavigate();
   const { festId } = useParams();
-  const { currentUser } = useContext(CurrentUserContext);
   const { openModal, closeModal, registerModal } = useModals();
 
-  // Fest Query
+  // Fest Query to pull fests from server
   const festQuery = useQuery(GET_FEST, {
-    variables: {
-      where: {
-        id: festId,
-      },
-    },
-  });
-
-  // Discussion Query
-  const discussionQuery = useQuery(GET_DISCUSSIONS, {
     variables: { where: { id: festId } },
   });
 
   // Movie Query
   const moviesQuery = useQuery(GET_MOVIES, { variables: { where: {} } });
-
-  // Remove Fest Mutation
-  const [deleteFest, { data, loading, error }] = useMutation(DELETE_FEST, {
-    refetchQueries: [GET_USER_FESTS],
-  });
-
-  // Function to remove a Fest
-  const removeFest = () => {
-    if (currentUser.id === festQuery.data.fest.creator.id) {
-      deleteFest({ variables: { where: { id: festId } } });
-      if (loading) return "Submitting...";
-      if (error) return `Submission error! ${error.message}`;
-      closeModal();
-      navigate("/profile/fests");
-    }
-  };
 
   const [
     updateFest,
@@ -74,24 +32,17 @@ export const FestRoute = () => {
     updateFest({
       variables: {
         where: { id: festId },
-        data: {
-          movies: {
-            connect: movieIds,
-          },
-        },
+        data: { movies: { connect: movieIds } },
       },
     });
   };
 
+  // Function to remove movies from server
   const removeMovie = (movieId) => {
     updateFest({
       variables: {
         where: { id: festId },
-        data: {
-          movies: {
-            disconnect: [{ id: movieId }],
-          },
-        },
+        data: { movies: { disconnect: [{ id: movieId }] } },
       },
     });
   };
@@ -139,77 +90,68 @@ export const FestRoute = () => {
         )}
         <div className="flex gap-x-24">
           {!festQuery.loading && festQuery?.data?.fest && (
-            <FestSidebar removeFest={removeFest} festQuery={festQuery} />
+            <FestSidebar festQuery={festQuery} />
           )}
-          {location.pathname === `/fests/${festId}` && (
-            <div className="flex flex-col gap-y-8">
-              <div className="flex justify-between items-center">
-                {!festQuery.loading && movies && movies.length > 0 && (
-                  <h2 className="font-arial text-lg/4 font-bold">
-                    Slops for this fest
-                  </h2>
-                )}
-                {!festQuery.loading && movies && movies.length === 0 && (
-                  <h2 className="font-arial text-lg/4 font-bold">
-                    {"No slops for this fest yet :("}
-                  </h2>
-                )}
-                <Button
-                  className="font-normal flex gap-x-2.5"
-                  size="sm"
-                  variant="outline-secondary"
-                  onClick={() => {
-                    openModal("add movie");
-                  }}
-                >
-                  <img
-                    className="w-5 h-5"
-                    src={magGlassDark}
-                    alt="black magnifying glass"
-                  />
-                  Search to add
-                </Button>
-              </div>
-              {!festQuery.loading && (
-                <MovieCardList
-                  movies={movies}
-                  colSpanOne
-                  minusButton
-                  minusButtonClick={removeMovie}
-                />
+          <div className="flex flex-col gap-y-8">
+            <div className="flex justify-between items-center">
+              {!festQuery.loading && movies && movies.length > 0 && (
+                <h2 className="font-arial text-lg/4 font-bold">
+                  Slops for this fest
+                </h2>
               )}
-              <span className="w-full border-b-[1px] border-gray" />
-              {!moviesQuery.loading &&
-                !festQuery.loading &&
-                recommendedMovies.length > 0 && (
-                  <>
-                    <h2 className="font-arial text-lg/4 font-bold">
-                      Recommended Movies
-                    </h2>
-                    <MovieCardList
-                      movies={recommendedMovies}
-                      colSpanOne
-                      plusButton
-                      plusButtonClick={addMovies}
-                    />
-                  </>
-                )}
-              {!moviesQuery.loading &&
-                !festQuery.loading &&
-                recommendedMovies.length === 0 && (
-                  <h2 className="font-arial text-lg/4 font-bold">
-                    {"No movies to recommend :("}
-                  </h2>
-                )}
+              {!festQuery.loading && movies && movies.length === 0 && (
+                <h2 className="font-arial text-lg/4 font-bold">
+                  {"No slops for this fest yet :("}
+                </h2>
+              )}
+              <Button
+                className="font-normal flex gap-x-2.5"
+                size="sm"
+                variant="outline-secondary"
+                onClick={() => {
+                  openModal("add movie");
+                }}
+              >
+                <img
+                  className="w-5 h-5"
+                  src={magGlassDark}
+                  alt="black magnifying glass"
+                />
+                Search to add
+              </Button>
             </div>
-          )}
-          {location.pathname === `/fests/${festId}/discussion` && (
-            <FestDiscussion
-              discussionQuery={discussionQuery}
-              festQuery={festQuery}
-              festId={festId}
-            />
-          )}
+            {!festQuery.loading && (
+              <MovieCardList
+                movies={movies}
+                colSpanOne
+                minusButton
+                minusButtonClick={removeMovie}
+              />
+            )}
+            <span className="w-full border-b-[1px] border-gray" />
+            {!moviesQuery.loading &&
+              !festQuery.loading &&
+              recommendedMovies.length > 0 && (
+                <>
+                  <h2 className="font-arial text-lg/4 font-bold">
+                    Recommended Movies
+                  </h2>
+                  <MovieCardList
+                    movies={recommendedMovies}
+                    colSpanOne
+                    plusButton
+                    plusButtonClick={addMovies}
+                  />
+                </>
+              )}
+            {!moviesQuery.loading &&
+              !festQuery.loading &&
+              recommendedMovies.length === 0 && (
+                <h2 className="font-arial text-lg/4 font-bold">
+                  {"No movies to recommend :("}
+                </h2>
+              )}
+          </div>
         </div>
       </div>
     </>

--- a/src/routes/fest-route/fest-sidebar.jsx
+++ b/src/routes/fest-route/fest-sidebar.jsx
@@ -32,11 +32,11 @@ export const FestSidebar = ({ festQuery }) => {
   const sidebarItems = [
     {
       title: "Slops to watch",
-      link: `${location.pathname}`,
+      link: `/fests/${festId}`,
     },
     {
       title: "Discussion",
-      link: `${location.pathname}/discussion`,
+      link: `/fests/${festId}/discussion`,
     },
     {
       title: "Edit dates & guests",


### PR DESCRIPTION
Fix: Refactored the fest-route to remove the need for conditional rendering of fest-discussion. The two routes are now independent of each other and have their logic separated. This allowed for fest-route to be cleaner.

## Describe your changes
- Removed the conditional rendering of fest-discussion inside of fest-route
- Changed `main.jsx` to render `<FestDiscussion>` when the user is at /:festId/discussion instead of FestRoute as previously done. 
- Moved all logic pertaining to discussions to the DiscussionRoute (useQuery for pulling discussions, and useMutation for adding discussions)
- Moved Logic for deleting fests to the FestSidebar route. This had to be done, so that an error would not be thrown now that FestSidebar is being used inside of FestRoute and FestDiscussion. This made more sense, since the delete button lives inside of the FestSidebar component. 

## Issue ticket number and link
[Slop-25](https://tripleten-apiary.atlassian.net/jira/software/projects/SLOP/boards/2?selectedIssue=SLOP-25)

## Checklist before requesting a review

- [X] I have performed a self-review of my code
- [ ] If there are changes to components, I have added / updated automated tests
- [ ] I have made any necessary updates to Storybook to accompany these changes
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
