### PR TITLE
refactor: remove export from graphql index.js

### DIFF
--- a/src/graphql/index.js
+++ b/src/graphql/index.js
@@ -7,6 +7,5 @@ export * from "./get-movies";
 export * from "./get-user-authentication";
 export * from "./get-user-fests";
 export * from "./get-users";
-export * from "./hook/useCurrentUser";
 export * from "./signin-users";
 export * from "./update-fest";


### PR DESCRIPTION
## Describe your changes
Removed an unnecessary export line from `/src/graphql/index.js` that was causing the build to fail

## Issue ticket number and link

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] If there are changes to components, I have added / updated automated tests
- [ ] I have made any necessary updates to Storybook to accompany these changes
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
