### PR TITLE
Slop 26: Improvement: Popover styling on Login Modal

### DIFF
--- a/src/components/login-modal.jsx
+++ b/src/components/login-modal.jsx
@@ -87,6 +87,7 @@ export function LoginModal({ onClose }) {
             id={"password"}
             labelText={"Password"}
             isValid={!errors.password}
+            type="password"
             onChange={(evt) => {
               setValue("password", evt.target.value, { shouldValidate: true });
             }}
@@ -126,7 +127,7 @@ export function LoginModal({ onClose }) {
                 >
                   <Popover.Panel className="absolute left-1/2 z-10 mt-3 w-screen max-w-sm -translate-x-1/2 transform px-4 sm:px-0 lg:max-w-3xl">
                     <div className="overflow-hidden bg-white rounded-lg shadow-lg ring-1 ring-black/5 border">
-                      <p className="p-5 font-arialRegular text-lg">
+                      <p className="p-4 font-arialRegular text-md/5 text-center xs:text-sm/5">
                         Please contact admin to reset password
                       </p>
                     </div>

--- a/src/components/signup-modal.jsx
+++ b/src/components/signup-modal.jsx
@@ -100,6 +100,7 @@ export const SignupModal = ({ onClose }) => {
             },
           })}
           labelText={"Password"}
+          type="password"
           onChange={(evt) => {
             setValue("password", evt.target.value, { shouldValidate: true });
           }}


### PR DESCRIPTION
Description:
Added the type='password' attribute to the login and signup modals to prevent other's from seeing it. Also fixed popover responsiveness to ensure it can undergo screen responsiveness and keep a clean design. The rest of the items on this ticket were covered in the 'fix/slop-27/improvement-modal-responsiveness' ticket. 

## Describe your changes
- Added the type="password' attribute to the password input on the Login and Signup Modals to prevent passwords from showing up when user types it in (as per Figma)
- Changed the popover text size so that it is a bit more responsive as the modal undergoes screen changes. 

## Issue ticket number and link
[Slop 26: Improvement: Popover styling on Login Modal](https://tripleten-apiary.atlassian.net/jira/software/projects/SLOP/boards/2?selectedIssue=SLOP-26)

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [ ] If there are changes to components, I have added / updated automated tests
- [ ] I have made any necessary updates to Storybook to accompany these changes
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
