### PR TITLE
Fix/slop 47/slop dropdown on blog post

### DIFF
--- a/src/page/blog/article-page.jsx
+++ b/src/page/blog/article-page.jsx
@@ -28,7 +28,15 @@ export const Article = () => {
     },
   });
   const { data: keywordsData } = useQuery(GET_KEYWORDS);
-  const { data: moviesData } = useQuery(GET_MOVIES);
+  const { data: moviesData } = useQuery(GET_MOVIES, {
+    variables: {
+      where: {
+        status: {
+          equals: "published",
+        },
+      },
+    },
+  });
   const keywordsPrefills = data?.post?.keywords?.map((keyword) => ({
     name: keyword.name,
   }));

--- a/src/page/blog/articles-page.jsx
+++ b/src/page/blog/articles-page.jsx
@@ -19,7 +19,7 @@ export const Articles = () => {
 
   return (
     <div className="max-w-[1440px] mx-auto">
-      <div className="flex mt-10 justify-end">
+      <div className="flex mt-10 justify-end mr-32">
         <a href="/draft" className="underline">
           Drafts
         </a>


### PR DESCRIPTION
## Describe your changes
When the user would attempt to create a new blog post, the "Slops" dropdown was not functional. I updated the way movies/slops were being queried and fixed the issue. Now a list of movies/slops will populate when the user clicks on the dropdown arrow like expected. 

## Issue ticket number and link
Slop-47-Fix Slop Dropdown When Writing a blog post
https://tripleten-apiary.atlassian.net/jira/software/projects/SLOP/boards/2?selectedIssue=SLOP-47 

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] If there are changes to components, I have added / updated automated tests
- [ ] I have made any necessary updates to Storybook to accompany these changes
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
