### PR TITLE
Feature/slop 35/delete draft blog post

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -98,18 +98,10 @@ export const App = () => {
                 element={<ProtectedRoute>{/* <Recommend /> */}</ProtectedRoute>}
               />
               <Route
-                path="/articles/:id/edit-published"
+                path="/articles/:id/edit"
                 element={
                   <ProtectedRoute>
-                    <ArticleRoute type={"edit-published"} />
-                  </ProtectedRoute>
-                }
-              />
-              <Route
-                path="/articles/:id/edit-draft"
-                element={
-                  <ProtectedRoute>
-                    <ArticleRoute type={"edit-draft"} />
+                    <ArticleRoute type={"edited"} />
                   </ProtectedRoute>
                 }
               />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -42,7 +42,7 @@ export const App = () => {
               <Route
                 exact
                 path="/articles/create"
-                element={<ArticleRoute isEdited={false} />}
+                element={<ArticleRoute type={"new"} />}
               />
               <Route exact path="/articles/:id" element={<ReviewRoute />} />
               <Route
@@ -98,10 +98,18 @@ export const App = () => {
                 element={<ProtectedRoute>{/* <Recommend /> */}</ProtectedRoute>}
               />
               <Route
-                path="/articles/:id/edit"
+                path="/articles/:id/edit-published"
                 element={
                   <ProtectedRoute>
-                    <ArticleRoute isEdited={true} />
+                    <ArticleRoute type={"edit-published"} />
+                  </ProtectedRoute>
+                }
+              />
+              <Route
+                path="/articles/:id/edit-draft"
+                element={
+                  <ProtectedRoute>
+                    <ArticleRoute type={"edit-draft"} />
                   </ProtectedRoute>
                 }
               />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -39,7 +39,11 @@ export const App = () => {
               <Route path="/sounds" element={<SoundsRoute />} />
               <Route path="/draft" element={<DraftRoute />} />
               <Route path="/articles" element={<ArticlesRoute />} />
-              <Route exact path="/articles/create" element={<ArticleRoute />} />
+              <Route
+                exact
+                path="/articles/create"
+                element={<ArticleRoute isEdited={false} />}
+              />
               <Route exact path="/articles/:id" element={<ReviewRoute />} />
               <Route
                 path="/profile/*"
@@ -97,7 +101,7 @@ export const App = () => {
                 path="/articles/:id/edit"
                 element={
                   <ProtectedRoute>
-                    <ArticleRoute />
+                    <ArticleRoute isEdited={true} />
                   </ProtectedRoute>
                 }
               />

--- a/src/components/blog/draft.jsx
+++ b/src/components/blog/draft.jsx
@@ -21,10 +21,7 @@ export const Draft = ({
 
   return (
     <div className={containerClass}>
-      <h2
-        onClick={() => router(`/articles/${id}/edit-draft`)}
-        className={titleClass}
-      >
+      <h2 onClick={() => router(`/articles/${id}/edit`)} className={titleClass}>
         {title}
       </h2>
       <div className={infoClass}>

--- a/src/components/blog/draft.jsx
+++ b/src/components/blog/draft.jsx
@@ -21,7 +21,10 @@ export const Draft = ({
 
   return (
     <div className={containerClass}>
-      <h2 onClick={() => router(`/articles/${id}/edit`)} className={titleClass}>
+      <h2
+        onClick={() => router(`/articles/${id}/edit-draft`)}
+        className={titleClass}
+      >
         {title}
       </h2>
       <div className={infoClass}>

--- a/src/page/blog/article-page.jsx
+++ b/src/page/blog/article-page.jsx
@@ -199,7 +199,7 @@ export const Article = ({ type }) => {
           {type === "edited" && (
             <button
               onClick={onDelete}
-              className=" absolute top-10 right-10 underline underline-offset-2 text-red-500"
+              className=" absolute top-10 right-10 bg-transparent text-danger font-bold text-lg mt-10"
             >
               Delete
             </button>

--- a/src/page/blog/article-page.jsx
+++ b/src/page/blog/article-page.jsx
@@ -16,7 +16,7 @@ import {
 import { useCurrentUser } from "../../hooks";
 import { ClientContext } from "../../store/client-context.js";
 
-export const Article = ({ isEdited }) => {
+export const Article = ({ type }) => {
   const { id } = useParams();
   const router = useNavigate();
   const [successful, setSuccessful] = useState(false);
@@ -185,7 +185,11 @@ export const Article = ({ isEdited }) => {
             },
           },
         });
-        router(`/draft`);
+        if (type === "edit-published") {
+          router("/articles");
+        } else if (type === "edit-draft") {
+          router(`/draft`);
+        }
       });
     }
   };
@@ -194,7 +198,7 @@ export const Article = ({ isEdited }) => {
     <>
       {!successful ? (
         <div className="relative flex flex-row justify-center mx-auto -top-5 pt-20">
-          {isEdited && (
+          {(type === "edit-draft" || type === "edit-published") && (
             <button
               onClick={onDelete}
               className=" absolute top-10 right-10 underline underline-offset-2 text-red-500"

--- a/src/page/blog/review-page.jsx
+++ b/src/page/blog/review-page.jsx
@@ -46,11 +46,11 @@ export const Review = ({ id }) => {
         setAccessGranted(true);
       }
     }
-  }, [data]);
+  }, [data, currentUser]);
 
   const onEdit = () => {
     if (currentUser.id === data.post.author.id) {
-      router(`/articles/${id}/edit-published`);
+      router(`/articles/${id}/edit`);
     }
   };
 

--- a/src/page/blog/review-page.jsx
+++ b/src/page/blog/review-page.jsx
@@ -50,7 +50,7 @@ export const Review = ({ id }) => {
 
   const onEdit = () => {
     if (currentUser.id === data.post.author.id) {
-      router(`/articles/${id}/edit`);
+      router(`/articles/${id}/edit-published`);
     }
   };
 

--- a/src/routes/blog-route/article-route.jsx
+++ b/src/routes/blog-route/article-route.jsx
@@ -1,7 +1,7 @@
 import { Header } from "../../components";
 import ArticlePage from "../../page/blog/article-page.jsx";
 
-export function ArticleRoute() {
+export function ArticleRoute({ isEdited }) {
   return (
     <>
       <div className="relative">
@@ -11,7 +11,7 @@ export function ArticleRoute() {
           <Header.Profile />
         </Header>
       </div>
-      <ArticlePage />
+      <ArticlePage isEdited={isEdited} />
     </>
   );
 }

--- a/src/routes/blog-route/article-route.jsx
+++ b/src/routes/blog-route/article-route.jsx
@@ -1,7 +1,7 @@
 import { Header } from "../../components";
 import ArticlePage from "../../page/blog/article-page.jsx";
 
-export function ArticleRoute({ isEdited }) {
+export function ArticleRoute({ type }) {
   return (
     <>
       <div className="relative">
@@ -11,7 +11,7 @@ export function ArticleRoute({ isEdited }) {
           <Header.Profile />
         </Header>
       </div>
-      <ArticlePage isEdited={isEdited} />
+      <ArticlePage type={type} />
     </>
   );
 }

--- a/src/routes/blog-route/draft-route.jsx
+++ b/src/routes/blog-route/draft-route.jsx
@@ -23,7 +23,7 @@ export function DraftRoute() {
       <div className="w-full max-w-[1440px] -top-5 mx-auto p-20 flex flex-row relative">
         <DraftPage />
       </div>
-      <div className="absolute bottom-0 w-full max-w-[989] mx-auto p-10">
+      <div className="-z-10 absolute bottom-0 w-full max-w-[989] mx-auto p-10">
         <Footer>{/* <Footer.Content></Footer.Content>{" "} */}</Footer>
       </div>
     </>


### PR DESCRIPTION
## Describe your changes
Added a delete button to be able to delete Draft Blog Posts.

![2024-04-27_11-16](https://github.com/jahorwitz/slopopedia/assets/112486038/c55ec565-1edb-4b05-bf46-c291f62829cc)
![2024-04-27_11-17](https://github.com/jahorwitz/slopopedia/assets/112486038/9153d76d-943b-4b26-b4d1-e6111c42ef82)

The delete button also currently shows up when editing a published blog post and is functional as well. But if we don't want a delete button there, I can easily remove that.

Update: I initially had 3 routes for the Article component: create, edit-published, and edit-draft. Upon request, I deleted a route and changed it back to the initial 2 routes.

## Issue ticket number and link
Slop-35. Add a button to delete draft blog posts
https://tripleten-apiary.atlassian.net/jira/software/projects/SLOP/boards/2?selectedIssue=SLOP-35

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] If there are changes to components, I have added / updated automated tests
- [ ] I have made any necessary updates to Storybook to accompany these changes
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
