### PR TITLE
fix/slop-58/positioning of movie tags/keywords

### DIFF
--- a/src/components/movie-card/movie-card.jsx
+++ b/src/components/movie-card/movie-card.jsx
@@ -68,7 +68,7 @@ export function MovieCard({
           size === 2 && "col-span-2",
           size === 3 && "col-span-3"
         )}
-        style={{ maxHeight: "80vh" }}
+        style={{ position: "relative" }}
         onClick={onClick}
         {...rest}
       >


### PR DESCRIPTION
## Describe your changes
I updated the style of the div responsible for setting the relative position necessary for the absolutely positioned keywords to use for correct placement. Screenshot attached to show what my local homepage looks like after this change. 

![image](https://github.com/jahorwitz/slopopedia/assets/126746048/7d2ce201-e1f0-4af0-845f-5560ce10eaa2)

## Issue ticket number and link
https://tripleten-apiary.atlassian.net/jira/software/projects/SLOP/boards/2?selectedIssue=SLOP-58

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] If there are changes to components, I have added / updated automated tests
- [ ] I have made any necessary updates to Storybook to accompany these changes
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
