### PR TITLE
Feature/SLOP-44/automate context uri for deployment

### DIFF
--- a/src/store/client-context-provider.jsx
+++ b/src/store/client-context-provider.jsx
@@ -4,51 +4,56 @@ import { useEffect, useState } from "react";
 import { ClientContext } from "./client-context";
 
 export const ClientContextProvider = ({ children }) => {
-  const [token, setToken] = useState(localStorage.getItem("jwt"));
-  const [client, setClient] = useState(null);
+    const [token, setToken] = useState(localStorage.getItem("jwt"));
+    const [client, setClient] = useState(null);
 
-  useEffect(() => {
-    const httpLink = createHttpLink({
-      uri: "https://slopopedia-api-a5fe9aef64e8.herokuapp.com/api/graphql",
-    });
+    const apiUri =
+        process.env.NODE_ENV === "production"
+            ? "https://slopopedia-api-a5fe9aef64e8.herokuapp.com/api/graphql"
+            : "http://localhost:8080/api/graphql";
 
-    const authLink = setContext((_, { headers }) => {
-      return {
-        headers: {
-          ...headers,
-          authorization: token ? `Bearer ${token}` : "",
-        },
-      };
-    });
-    setClient(
-      new ApolloClient({
-        link: authLink.concat(httpLink),
-        cache: new InMemoryCache(),
-      })
-    );
-  }, []);
+    useEffect(() => {
+        const httpLink = createHttpLink({
+            uri: apiUri,
+        });
 
-  useEffect(() => {
-    if (client) {
-      const httpLink = createHttpLink({
-        uri: "https://slopopedia-api-a5fe9aef64e8.herokuapp.com/api/graphql",
-      });
+        const authLink = setContext((_, { headers }) => {
+            return {
+                headers: {
+                    ...headers,
+                    authorization: token ? `Bearer ${token}` : "",
+                },
+            };
+        });
+        setClient(
+            new ApolloClient({
+                link: authLink.concat(httpLink),
+                cache: new InMemoryCache(),
+            })
+        );
+    }, []);
 
-      const authLink = setContext((_, { headers }) => {
-        return {
-          headers: {
-            ...headers,
-            authorization: token ? `Bearer ${token}` : "",
-          },
-        };
-      });
-      client.setLink(authLink.concat(httpLink));
-    }
-  }, [token, client]);
+    useEffect(() => {
+        if (client) {
+            const httpLink = createHttpLink({
+                uri: apiUri,
+            });
 
-  return client ? (
-    <ClientContext.Provider value={{ token, setToken, client }}>
-      {children}
-    </ClientContext.Provider>
-  ) : null;
+            const authLink = setContext((_, { headers }) => {
+                return {
+                    headers: {
+                        ...headers,
+                        authorization: token ? `Bearer ${token}` : "",
+                    },
+                };
+            });
+            client.setLink(authLink.concat(httpLink));
+        }
+    }, [token, client]);
+
+    return client ? (
+        <ClientContext.Provider value={{ token, setToken, client }}>
+            {children}
+        </ClientContext.Provider>
+    ) : null;
 };

--- a/src/store/client-context-provider.jsx
+++ b/src/store/client-context-provider.jsx
@@ -4,56 +4,56 @@ import { useEffect, useState } from "react";
 import { ClientContext } from "./client-context";
 
 export const ClientContextProvider = ({ children }) => {
-    const [token, setToken] = useState(localStorage.getItem("jwt"));
-    const [client, setClient] = useState(null);
+  const [token, setToken] = useState(localStorage.getItem("jwt"));
+  const [client, setClient] = useState(null);
 
-    const apiUri =
-        process.env.NODE_ENV === "production"
-            ? "https://slopopedia-api-a5fe9aef64e8.herokuapp.com/api/graphql"
-            : "http://localhost:8080/api/graphql";
+  const apiUri =
+    process.env.NODE_ENV === "production"
+      ? "https://slopopedia-api-a5fe9aef64e8.herokuapp.com/api/graphql"
+      : "http://localhost:8080/api/graphql";
 
-    useEffect(() => {
-        const httpLink = createHttpLink({
-            uri: apiUri,
-        });
+  useEffect(() => {
+    const httpLink = createHttpLink({
+      uri: apiUri,
+    });
 
-        const authLink = setContext((_, { headers }) => {
-            return {
-                headers: {
-                    ...headers,
-                    authorization: token ? `Bearer ${token}` : "",
-                },
-            };
-        });
-        setClient(
-            new ApolloClient({
-                link: authLink.concat(httpLink),
-                cache: new InMemoryCache(),
-            })
-        );
-    }, []);
+    const authLink = setContext((_, { headers }) => {
+      return {
+        headers: {
+          ...headers,
+          authorization: token ? `Bearer ${token}` : "",
+        },
+      };
+    });
+    setClient(
+      new ApolloClient({
+        link: authLink.concat(httpLink),
+        cache: new InMemoryCache(),
+      })
+    );
+  }, []);
 
-    useEffect(() => {
-        if (client) {
-            const httpLink = createHttpLink({
-                uri: apiUri,
-            });
+  useEffect(() => {
+    if (client) {
+      const httpLink = createHttpLink({
+        uri: apiUri,
+      });
 
-            const authLink = setContext((_, { headers }) => {
-                return {
-                    headers: {
-                        ...headers,
-                        authorization: token ? `Bearer ${token}` : "",
-                    },
-                };
-            });
-            client.setLink(authLink.concat(httpLink));
-        }
-    }, [token, client]);
+      const authLink = setContext((_, { headers }) => {
+        return {
+          headers: {
+            ...headers,
+            authorization: token ? `Bearer ${token}` : "",
+          },
+        };
+      });
+      client.setLink(authLink.concat(httpLink));
+    }
+  }, [token, client]);
 
-    return client ? (
-        <ClientContext.Provider value={{ token, setToken, client }}>
-            {children}
-        </ClientContext.Provider>
-    ) : null;
+  return client ? (
+    <ClientContext.Provider value={{ token, setToken, client }}>
+      {children}
+    </ClientContext.Provider>
+  ) : null;
 };


### PR DESCRIPTION
## Describe your changes

Replaced hardcoded URI with variable.

While NODE_ENV is set to production, it will set the URI to the production API. Otherwise it will point to http://localhost:8080/api/graphql.

I also wrote a script to do it on deployment instead of using JS, but this seems like a far easier solution that accomplishes the desired outcome.

## Issue ticket number and link

SLOP-44 Dynamically change Context URI Based on Env

https://tripleten-apiary.atlassian.net/browse/SLOP-44?atlOrigin=eyJpIjoiN2Q0NjZiZjgxY2IxNDllOWE1MDJjNDQzOTBhZTY4NjIiLCJwIjoiaiJ9

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If there are changes to components, I have added / updated automated tests
- [x] I have made any necessary updates to Storybook to accompany these changes
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
