### PR TITLE
fix/slop-40/font file error

### DIFF
--- a/src/global/font.css
+++ b/src/global/font.css
@@ -1,14 +1,14 @@
 @font-face {
-    font-family: 'Arial-Regular';
-    src: url("../src/vendor/fonts/ARIAL.woff");
+  font-family: "Arial-Regular";
+  src: url("../vendor/fonts/ARIAL.woff");
 }
 
 @font-face {
-    font-family: "Arial-Bold";
-    src: url("../src/vendor/fonts/ARIALBD.woff");
+  font-family: "Arial-Bold";
+  src: url("../vendor/fonts/ARIALBD.woff");
 }
 
 @font-face {
-    font-family: "Arial-NarrowBold";
-    src: url("../src/vendor/fonts/ARIALNB.woff");
+  font-family: "Arial-NarrowBold";
+  src: url("../vendor/fonts/ARIALNB.woff");
 }


### PR DESCRIPTION
## Describe your changes

Corrected the font file paths in the CSS to properly reference the `vendor/fonts` directory, ensuring the fonts are loaded as expected during the build process.

## Issue ticket number and link

[slop-40](https://tripleten-apiary.atlassian.net/jira/software/projects/SLOP/boards/2?selectedIssue=SLOP-40)

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] If there are changes to components, I have added / updated automated tests
- [ ] I have made any necessary updates to Storybook to accompany these changes
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
