### PR TITLE
fix: slop-60 / Side bar links on Draft List Page are not Clickable

### DIFF
--- a/src/routes/blog-route/draft-route.jsx
+++ b/src/routes/blog-route/draft-route.jsx
@@ -12,7 +12,7 @@ export function DraftRoute() {
           <Header.Profile />
         </Header>
       </div>
-      <div className="relative float-right -top-10left-3/4 mr-32 mt-10 flex">
+      <div className="z-10 relative float-right -top-10left-3/4 mr-32 mt-10 flex">
         <Link to={"/draft"} className="underline">
           Drafts
         </Link>


### PR DESCRIPTION
## Describe your changes
A very quick change to the z-index, so that the links shown in the image on jira, are now clickable.

## Issue ticket number and link
slop-60
https://tripleten-apiary.atlassian.net/jira/software/projects/SLOP/boards/2?selectedIssue=SLOP-60

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] If there are changes to components, I have added / updated automated tests
- [ ] I have made any necessary updates to Storybook to accompany these changes
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
