### PR TITLE
Fix/SLOP-59/Keyword Tagging when Submitting a Slop

### DIFF
--- a/src/routes/submit-route/submit-slop-form.jsx
+++ b/src/routes/submit-route/submit-slop-form.jsx
@@ -88,7 +88,7 @@ export const SubmitSlopForm = () => {
             //   upload: data.photo
             // },
             keywords: {
-              connect: movieKeywords.map((keyword) => ({
+              connect: keywords.map((keyword) => ({
                 id: keyword.id,
               })),
             },
@@ -282,11 +282,12 @@ export const SubmitSlopForm = () => {
         <Form.Combobox
           list={movieKeywords.map((keyword) => ({
             name: keyword.name,
+            id: keyword.id,
           }))}
           watch={watch}
           setValue={setValue}
           labelText={"Keywords"}
-          id={"Keywords"}
+          id={"keywords"}
           nameKey={"name"}
           idKey={"name"}
           name={"Keywords"}


### PR DESCRIPTION
## Describe your changes

All keywords were being mapped to the form submission rather than only the keywords selected in the combo box. Also changed some minor capitalization to match form input naming convention.

## Issue ticket number and link

[SLOP-59](https://tripleten-apiary.atlassian.net/jira/software/projects/SLOP/boards/2?selectedIssue=SLOP-59)

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] If there are changes to components, I have added / updated automated tests
- [ ] I have made any necessary updates to Storybook to accompany these changes
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
