### PR TITLE
Fix / Slop-65 / Submit slop form validation

### DIFF
--- a/src/routes/submit-route/submit-slop-form.jsx
+++ b/src/routes/submit-route/submit-slop-form.jsx
@@ -241,6 +241,9 @@ export const SubmitSlopForm = () => {
               isValid={!errors.runtime}
               classNameInput="bg-white"
             />
+            {errors.runtime && (
+              <Form.Feedback message={errors.runtime.message} />
+            )}
           </div>
         </div>
         {/* // For future use */}

--- a/src/routes/submit-route/submit-slop-form.jsx
+++ b/src/routes/submit-route/submit-slop-form.jsx
@@ -200,15 +200,21 @@ export const SubmitSlopForm = () => {
               register={register("releaseYear", {
                 minLength: {
                   value: 4,
-                  message: "Please enter 4 or more characters",
+                  message: "Please enter 4 digits",
+                },
+                maxLength: {
+                  value: 4,
+                  message: "Please do not enter more than 4 digits",
                 },
               })}
               placeholder="Release Year"
               labelText="Release Year"
               onChange={(e) => {
-                setValue("releaseYear", e.target.value, {
-                  shouldValidate: true,
-                });
+                if (!isNaN(e.target.value)) {
+                  setValue("releaseYear", e.target.value, {
+                    shouldValidate: true,
+                  });
+                }
               }}
               isValid={!errors.releaseYear}
               classNameInput="bg-white"

--- a/src/routes/submit-route/submit-slop-form.jsx
+++ b/src/routes/submit-route/submit-slop-form.jsx
@@ -225,11 +225,14 @@ export const SubmitSlopForm = () => {
           </div>
           <div className="flex flex-col">
             <Form.TextInput
+              maxLength={3}
               value={runtime}
               placeholder="Runtime"
               labelText="Runtime"
               onChange={(e) => {
-                setValue("runtime", e.target.value, { shouldValidate: true });
+                if (!isNaN(e.target.value) && e.target.value !== " ") {
+                  setValue("runtime", e.target.value, { shouldValidate: true });
+                }
               }}
               isValid={!errors.runtime}
               classNameInput="bg-white"

--- a/src/routes/submit-route/submit-slop-form.jsx
+++ b/src/routes/submit-route/submit-slop-form.jsx
@@ -195,17 +195,19 @@ export const SubmitSlopForm = () => {
         <div className="xs:flex-col sm:flex md:flex lg:flex xl:flex justify-between font-arialBold text-lg box-border ">
           <div className="flex flex-col">
             <Form.TextInput
+              required
               maxLength={4}
               value={releaseYear}
               errors={errors}
               register={register("releaseYear", {
+                required: "Release Year is required",
                 minLength: {
                   value: 4,
                   message: "Please enter 4 digits",
                 },
               })}
               placeholder="Release Year"
-              labelText="Release Year"
+              labelText="Release Year *"
               onChange={(e) => {
                 if (!isNaN(e.target.value) && e.target.value !== " ") {
                   setValue("releaseYear", e.target.value, {
@@ -222,10 +224,15 @@ export const SubmitSlopForm = () => {
           </div>
           <div className="flex flex-col">
             <Form.TextInput
+              required
               maxLength={3}
               value={runtime}
+              errors={errors}
+              register={register("runtime", {
+                required: "Runtime is required",
+              })}
               placeholder="Runtime"
-              labelText="Runtime"
+              labelText="Runtime *"
               onChange={(e) => {
                 if (!isNaN(e.target.value) && e.target.value !== " ") {
                   setValue("runtime", e.target.value, { shouldValidate: true });

--- a/src/routes/submit-route/submit-slop-form.jsx
+++ b/src/routes/submit-route/submit-slop-form.jsx
@@ -195,6 +195,7 @@ export const SubmitSlopForm = () => {
         <div className="xs:flex-col sm:flex md:flex lg:flex xl:flex justify-between font-arialBold text-lg box-border ">
           <div className="flex flex-col">
             <Form.TextInput
+              maxLength={4}
               value={releaseYear}
               errors={errors}
               register={register("releaseYear", {
@@ -202,15 +203,11 @@ export const SubmitSlopForm = () => {
                   value: 4,
                   message: "Please enter 4 digits",
                 },
-                maxLength: {
-                  value: 4,
-                  message: "Please do not enter more than 4 digits",
-                },
               })}
               placeholder="Release Year"
               labelText="Release Year"
               onChange={(e) => {
-                if (!isNaN(e.target.value)) {
+                if (!isNaN(e.target.value) && e.target.value !== " ") {
                   setValue("releaseYear", e.target.value, {
                     shouldValidate: true,
                   });


### PR DESCRIPTION
## Describe your changes
Edit both releaseYear and runtime slop submission inputs to only accept 4 and 3 digits respectively. 

In the case of making these required fields, as the story seems to suggest, when reviewing the design spec on figma, Release Year and Runtime do not seem to be required fields. For that reason I left them as not required, but I can easily change this if need be, just let me know one way or another. 

## Issue ticket number and link
Slop-65
https://tripleten-apiary.atlassian.net/browse/SLOP-65?atlOrigin=eyJpIjoiNWJmNDYwZjRjZmEzNDUwMjhkZWIyNmI2ZjYyYTdiNGEiLCJwIjoiaiJ9

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] If there are changes to components, I have added / updated automated tests
- [ ] I have made any necessary updates to Storybook to accompany these changes
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
