### PR TITLE
Fix/Slop-64/RSVP button on fest page

### DIFF
--- a/src/routes/fest-route/fest-header.jsx
+++ b/src/routes/fest-route/fest-header.jsx
@@ -1,10 +1,12 @@
+import { useMutation } from "@apollo/client";
 import { Button, Keyword } from "../../components";
+import { UPDATE_FEST } from "../../graphql";
 import { useCurrentUser } from "../../hooks";
 import checkMarkBlack from "../../images/check-mark-dark.svg";
 import checkMarkWhite from "../../images/check-mark.svg";
 
 export const FestHeader = ({ fest }) => {
-  let { name, invitees, startDate, endDate, attendees } = fest;
+  let { name, invitees, startDate, endDate, attendees, id: festId } = fest;
   startDate = new Intl.DateTimeFormat("en-US").format(new Date(startDate));
   endDate = new Intl.DateTimeFormat("en-US").format(new Date(endDate));
   const { currentUser } = useCurrentUser();
@@ -14,22 +16,79 @@ export const FestHeader = ({ fest }) => {
     (person) => person?.id === userId
   )[0];
 
+  const [updateFest] = useMutation(UPDATE_FEST, {});
+
+  const isAttendee = attendees.some((user) => user.id === currentUser.id);
+  const isInvitee = invitees.some((user) => user.id === currentUser.id);
+
+  const handleRSVPButtonClick = () => {
+    // if invited, add user to attendees, and remove user from invitees
+    if (isInvitee) {
+      updateFest({
+        variables: {
+          data: {
+            attendees: {
+              connect: [{ id: currentUser.id }],
+            },
+            invitees: {
+              disconnect: [{ id: currentUser.id }],
+            },
+          },
+          where: {
+            id: festId,
+          },
+        },
+      }).catch((err) => {
+        console.error(
+          err,
+          "Failed to add current user as an attendee of this fest."
+        );
+      });
+    } else {
+      // if and attendee, add user to invitees, and remove user from attendees
+      updateFest({
+        variables: {
+          data: {
+            invitees: {
+              connect: [{ id: currentUser.id }],
+            },
+            attendees: {
+              disconnect: [{ id: currentUser.id }],
+            },
+          },
+          where: {
+            id: festId,
+          },
+        },
+      }).catch((err) => {
+        console.error(
+          err,
+          "Failed to add current user as an invitee of this fest."
+        );
+      });
+    }
+  };
+
   return (
     <div className="flex flex-col gap-y-4 py-10">
       <div className="flex justify-between items-center">
         <h1 className="font-arial scale-y-2 font-bold">{name.toUpperCase()}</h1>
-        <Button
-          variant={ownerIsGoing ? "secondary" : "outline-secondary"}
-          size="sm"
-          className="flex items-center gap-x-2.5 pb-3 cursor-default"
-        >
-          <img
-            src={ownerIsGoing ? checkMarkWhite : checkMarkBlack}
-            className="w-4 h-3"
-            alt="white check mark"
-          />
-          I'm going!
-        </Button>
+
+        {(isAttendee || isInvitee) && (
+          <Button
+            variant={ownerIsGoing ? "secondary" : "outline-secondary"}
+            size="sm"
+            className="flex items-center gap-x-2.5 pb-3 cursor-default"
+            onClick={handleRSVPButtonClick}
+          >
+            <img
+              src={ownerIsGoing ? checkMarkWhite : checkMarkBlack}
+              className="w-4 h-3"
+              alt="white check mark"
+            />
+            I'm going!
+          </Button>
+        )}
       </div>
       <div className="flex justify-between items-center">
         <div className="flex flex-wrap gap-2.5 max-w-lg">

--- a/src/routes/fest-route/fest-route.jsx
+++ b/src/routes/fest-route/fest-route.jsx
@@ -1,5 +1,5 @@
 import { useMutation, useQuery } from "@apollo/client";
-import { useEffect, useMemo, useState } from "react";
+import { useMemo } from "react";
 import { useNavigate, useParams } from "react-router";
 import { Button, Header, Loading, MovieCardList } from "../../components";
 import { GET_FEST, GET_MOVIES } from "../../graphql/";
@@ -13,7 +13,6 @@ export const FestRoute = () => {
   const { festId } = useParams();
   const { openModal, closeModal } = useModals();
   const router = useNavigate();
-  const [isAuthorized, setIsAuthorized] = useState(false);
 
   // Fest Query to pull fests from server
   const festQuery = useQuery(GET_FEST, {
@@ -27,23 +26,6 @@ export const FestRoute = () => {
     updateFest,
     { data: updateData, loading: updateLoading, error: updateError },
   ] = useMutation(UPDATE_FEST, { refetchQueries: [GET_FEST] });
-
-  // route a user away from /fest/:festId endpoint if they are not an attendee or invitee of the fest
-  // prevents user from typing in the url, and seeing a fest they don't belong to
-  useEffect(() => {
-    if (!festQuery.loading) {
-      const isAttendee = festQuery?.data?.fest?.attendees.some(
-        (user) => user.id === currentUser.id
-      );
-      const isInvitee = festQuery?.data?.fest?.invitees.some(
-        (user) => user.id === currentUser.id
-      );
-      setIsAuthorized(isAttendee || isInvitee);
-      if (!isAttendee && !isInvitee) {
-        router("/profile/fests");
-      }
-    }
-  }, [festQuery?.loading]);
 
   const addMovies = (movies) => {
     const movieIds = movies.map((movie) => {
@@ -103,7 +85,7 @@ export const FestRoute = () => {
         <Header.NavLinks />
         <Header.Profile />
       </Header>
-      {isAuthorized && (
+      {
         <div className="max-w-[1200px] my-0 mx-auto box-border">
           {!festQuery.loading && festQuery?.data?.fest && (
             <FestHeader fest={festQuery.data.fest} />
@@ -172,7 +154,7 @@ export const FestRoute = () => {
             </div>
           </div>
         </div>
-      )}
+      }
     </>
   );
 };

--- a/src/routes/fest-route/fest-route.jsx
+++ b/src/routes/fest-route/fest-route.jsx
@@ -1,18 +1,16 @@
 import { useMutation, useQuery } from "@apollo/client";
 import { useMemo } from "react";
-import { useNavigate, useParams } from "react-router";
+import { useParams } from "react-router";
 import { Button, Header, Loading, MovieCardList } from "../../components";
 import { GET_FEST, GET_MOVIES } from "../../graphql/";
 import { UPDATE_FEST } from "../../graphql/mutations/fest";
-import { useCurrentUser, useModals } from "../../hooks";
+import { useModals } from "../../hooks";
 import magGlassDark from "../../images/mag-glass-black.svg";
 import { FestHeader, FestModal, FestSidebar } from "../fest-route";
 
 export const FestRoute = () => {
-  const { currentUser } = useCurrentUser();
   const { festId } = useParams();
   const { openModal, closeModal } = useModals();
-  const router = useNavigate();
 
   // Fest Query to pull fests from server
   const festQuery = useQuery(GET_FEST, {

--- a/src/routes/fest-route/fest-sidebar.jsx
+++ b/src/routes/fest-route/fest-sidebar.jsx
@@ -74,7 +74,7 @@ export const FestSidebar = ({ festQuery }) => {
           </Button>
         </Sidebar>
       </div>
-      {currentUser.id === festQuery.data.fest.creator.id ? (
+      {currentUser.id === festQuery.data.fest.creator?.id ? (
         <div>
           <Button
             type="button"

--- a/src/routes/profile-route/profile-fests-route.jsx
+++ b/src/routes/profile-route/profile-fests-route.jsx
@@ -18,13 +18,26 @@ export const ProfileFestsRoute = () => {
   const { loading, data } = useQuery(GET_USER_FESTS, {
     variables: {
       where: {
-        invitees: {
-          some: {
-            id: {
-              equals: currentUser.id,
+        OR: [
+          {
+            invitees: {
+              some: {
+                id: {
+                  equals: currentUser.id,
+                },
+              },
             },
           },
-        },
+          {
+            attendees: {
+              some: {
+                id: {
+                  equals: currentUser.id,
+                },
+              },
+            },
+          },
+        ],
       },
     },
   });
@@ -46,6 +59,9 @@ export const ProfileFestsRoute = () => {
             attendees: {
               connect: [{ id: currentUser.id }],
             },
+            invitees: {
+              disconnect: [{ id: currentUser.id }],
+            },
           },
           where: {
             id: fest.id,
@@ -56,6 +72,9 @@ export const ProfileFestsRoute = () => {
       updateFest({
         variables: {
           data: {
+            invitees: {
+              connect: [{ id: currentUser.id }],
+            },
             attendees: {
               disconnect: [{ id: currentUser.id }],
             },

--- a/src/store/client-context-provider.jsx
+++ b/src/store/client-context-provider.jsx
@@ -37,6 +37,11 @@ export const ClientContextProvider = ({ children }) => {
                     return incoming;
                   },
                 },
+                invitees: {
+                  merge(existing, incoming) {
+                    return incoming;
+                  },
+                },
               },
             },
           },

--- a/src/store/client-context-provider.jsx
+++ b/src/store/client-context-provider.jsx
@@ -28,7 +28,19 @@ export const ClientContextProvider = ({ children }) => {
     setClient(
       new ApolloClient({
         link: authLink.concat(httpLink),
-        cache: new InMemoryCache(),
+        cache: new InMemoryCache({
+          typePolicies: {
+            Fest: {
+              fields: {
+                attendees: {
+                  merge(existing, incoming) {
+                    return incoming;
+                  },
+                },
+              },
+            },
+          },
+        }),
       })
     );
   }, []);


### PR DESCRIPTION
## Describe your changes
**Important - To work properly, this must be running with this backend branch:**
https://github.com/jahorwitz/slopopedia-api/pull/11

With these 2 branches running, we should be able to click the "I'm going" button on the fests page, with no errors occurring.

The change in this particular branch fixes an error that occurs sometimes when clicking the "I'm going" button on the fests page. Due to trouble merging the attendees field in the cache, it sometimes caused extra fetching to the server. 

With this branch running, we should no longer get this error:
![2024-05-09_09-28](https://github.com/jahorwitz/slopopedia/assets/112486038/ea701c5b-ed96-46fc-a559-b31749a22e49)

## Issue ticket number and link
slop-64
https://tripleten-apiary.atlassian.net/jira/software/projects/SLOP/boards/2?selectedIssue=SLOP-64

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] If there are changes to components, I have added / updated automated tests
- [ ] I have made any necessary updates to Storybook to accompany these changes
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
