### PR TITLE
feat/slop-37/fest attendees

### DIFF
--- a/src/components/keyword.jsx
+++ b/src/components/keyword.jsx
@@ -1,7 +1,7 @@
 export const Keyword = ({ keyword, className }) => {
   return (
     <p
-      className={`inline-flex items-center p-2 min-h-[31px] w-max text-base font-arial break-words ${className}`}
+      className={`inline-flex items-center p-2 h-31 w-max text-base font-arial break-words leading-4 ${className}`}
     >
       {keyword}
     </p>

--- a/src/routes/fest-route/fest-header.jsx
+++ b/src/routes/fest-route/fest-header.jsx
@@ -33,6 +33,13 @@ export const FestHeader = ({ fest }) => {
       </div>
       <div className="flex justify-between items-center">
         <div className="flex flex-wrap gap-2.5 max-w-lg">
+          {attendees.map((attendee, index) => (
+            <Keyword
+              className="bg-yellow"
+              key={index}
+              keyword={attendee.username}
+            />
+          ))}
           {invitees.map((invitee, index) => (
             <Keyword
               className="bg-gray"

--- a/src/routes/profile-route/profile-fests-route.jsx
+++ b/src/routes/profile-route/profile-fests-route.jsx
@@ -153,11 +153,10 @@ export const ProfileFestsRoute = () => {
                               />
                             ))}
 
-                          {/* Additional Invitees Count */}
                           {fest.attendees?.length + fest.invitees?.length >
                             4 && (
                             <Keyword
-                              key="additional-persons"
+                              key={fest.id}
                               className="h-31px space-x-2 space-y-2 bg-gray xs:space-x-2 xs:space-y-2 text-black text-center mr-2.5"
                               keyword={`+ ${
                                 fest.attendees?.length +

--- a/src/routes/profile-route/profile-fests-route.jsx
+++ b/src/routes/profile-route/profile-fests-route.jsx
@@ -115,7 +115,7 @@ export const ProfileFestsRoute = () => {
                       <h3 className="font-arialBold mb-2.5">
                         <Link to={`/fests/${fest.id}`}>{fest.name}</Link>
                       </h3>
-                      <p className="font-arialRegular mb-2.5">
+                      <p className="font-arialRegular mb-2.5 opacity-60">
                         {startDate + " - " + endDate}
                       </p>
                       <div>

--- a/src/routes/profile-route/profile-fests-route.jsx
+++ b/src/routes/profile-route/profile-fests-route.jsx
@@ -112,10 +112,10 @@ export const ProfileFestsRoute = () => {
                     className="flex flex-row justify-between mb-5 border-b border-black"
                   >
                     <div className="mb-5">
-                      <h3 className="font-arialBold mb-2.5">
+                      <h3 className="font-arialBold mb-2.5 text-lg">
                         <Link to={`/fests/${fest.id}`}>{fest.name}</Link>
                       </h3>
-                      <p className="font-arialRegular mb-2.5 opacity-60">
+                      <p className="font-arialRegular mb-2.5 opacity-60 text-lg">
                         {startDate + " - " + endDate}
                       </p>
                       <div>

--- a/src/routes/profile-route/profile-fests-route.jsx
+++ b/src/routes/profile-route/profile-fests-route.jsx
@@ -120,34 +120,32 @@ export const ProfileFestsRoute = () => {
                       </p>
                       <div>
                         <div className="flex flex-row">
-                          {fest.invitees?.length <= 4
-                            ? fest.invitees?.map((invitee) => {
-                                return (
-                                  <Keyword
-                                    key={invitee.id}
-                                    className="h-31px space-x-2 space-y-2 bg-gray xs:space-x-2 xs:space-y-2 text-black text-center mr-2.5"
-                                    keyword={invitee.username}
-                                  />
-                                );
-                              })
-                            : fest.invitees?.slice(0, 4).map((invitee) => {
-                                // needs to have {+ invitees.length - 5} to show how many invitees after 5
-                                return (
-                                  <Keyword
-                                    key={invitee.id}
-                                    className="h-31px space-x-2 space-y-2 bg-gray xs:space-x-2 xs:space-y-2 text-black text-center mr-2.5"
-                                    keyword={invitee.username}
-                                  />
-                                );
-                              })}
-                          {fest.invitees?.length > 4 ? (
+                          {[...(fest.attendees ?? []), ...(fest.invitees ?? [])]
+                            .slice(0, 4)
+                            .map((person, index) => (
+                              <Keyword
+                                key={person.id}
+                                className={`h-31px space-x-2 space-y-2 ${
+                                  index < fest.attendees?.length
+                                    ? "bg-yellow"
+                                    : "bg-gray"
+                                } xs:space-x-2 xs:space-y-2 text-black text-center mr-2.5`}
+                                keyword={person.username}
+                              />
+                            ))}
+
+                          {/* Additional Invitees Count */}
+                          {fest.attendees?.length + fest.invitees?.length >
+                            4 && (
                             <Keyword
-                              key={fest.id}
+                              key="additional-persons"
                               className="h-31px space-x-2 space-y-2 bg-gray xs:space-x-2 xs:space-y-2 text-black text-center mr-2.5"
-                              keyword={`+ ${fest.invitees?.length - 4} more`}
+                              keyword={`+ ${
+                                fest.attendees?.length +
+                                fest.invitees?.length -
+                                4
+                              } more`}
                             />
-                          ) : (
-                            ""
                           )}
                         </div>
                       </div>


### PR DESCRIPTION
## Describe your changes
Implemented a feature on the Slop Fest page to visually differentiate between attendees and invitees. Attendees who have RSVP'ed 'attending' are now displayed with a yellow pill, while invitees who haven't RSVP'ed appear with a gray pill. 
![image](https://github.com/jahorwitz/slopopedia/assets/70713202/8ba1b474-df8d-4ee1-a485-e7a634548396)

## Issue ticket number and link
[slop-37](https://tripleten-apiary.atlassian.net/jira/software/projects/SLOP/boards/2?selectedIssue=SLOP-37)

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] If there are changes to components, I have added / updated automated tests
- [ ] I have made any necessary updates to Storybook to accompany these changes
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
