### PR TITLE
Fix/slop-76 Can't edit fest without editing title

### DIFF
--- a/src/components/slop-fest-modal.jsx
+++ b/src/components/slop-fest-modal.jsx
@@ -22,6 +22,7 @@ export function SlopFestModal({ buttonTitle, location, fest }) {
     if (location?.pathname === `/fests/${festId}`) {
       setValue("startDate", festStart);
       setValue("endDate", festEnd);
+      setValue("name", fest?.data?.fest?.name);
     }
   }, [fest?.data]);
 
@@ -103,7 +104,6 @@ export function SlopFestModal({ buttonTitle, location, fest }) {
           },
         }).then((e) => {
           closeModal("edit-fest");
-          e.preventDefault();
         });
       } catch (error) {
         console.log(`Error: ${error.message}`);


### PR DESCRIPTION
## Describe your changes
The fest modal can not be submitted without first editing the title.

## Issue ticket number and link
slop 76
https://tripleten-apiary.atlassian.net/jira/software/projects/SLOP/boards/2?selectedIssue=SLOP-76

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] If there are changes to components, I have added / updated automated tests
- [ ] I have made any necessary updates to Storybook to accompany these changes
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
