### PR TITLE
Fix/slop-70 User Viewing a Fest Created by a now-deleted User

### DIFF
--- a/src/routes/fest-route/fest-sidebar.jsx
+++ b/src/routes/fest-route/fest-sidebar.jsx
@@ -74,7 +74,7 @@ export const FestSidebar = ({ festQuery }) => {
           </Button>
         </Sidebar>
       </div>
-      {currentUser.id === festQuery.data.fest.creator.id ? (
+      {currentUser.id === festQuery?.data?.fest?.creator?.id ? (
         <div>
           <Button
             type="button"


### PR DESCRIPTION
## Describe your changes
A very short fix so that an invitee to a fest, can now view a fest that was created by a deleted user.

## Issue ticket number and link
slop-70
https://tripleten-apiary.atlassian.net/jira/software/projects/SLOP/boards/2?selectedIssue=SLOP-70

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] If there are changes to components, I have added / updated automated tests
- [ ] I have made any necessary updates to Storybook to accompany these changes
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
