### PR TITLE
Feat/Slop-77 Fest Invitee Should Not Be able to Edit Date or Guests

### DIFF
--- a/src/routes/fest-route/fest-sidebar.jsx
+++ b/src/routes/fest-route/fest-sidebar.jsx
@@ -14,6 +14,8 @@ export const FestSidebar = ({ festQuery }) => {
   const { openModal, closeModal } = useModals();
   const festId = useParams().festId;
   const navigate = useNavigate();
+  const festCreatorId = festQuery?.data?.fest?.creator?.id;
+  const isFestCreator = currentUser.id === festCreatorId;
 
   // Mutation to remove fests from server
   const [deleteFest, { data, loading, error }] = useMutation(DELETE_FEST, {
@@ -64,17 +66,19 @@ export const FestSidebar = ({ festQuery }) => {
           {sidebarItems.map((item, index) => (
             <Sidebar.Item key={index} link={item.link} title={item.title} />
           ))}
-          <Button
-            variant="link-secondary"
-            className={"ml-5"}
-            size="link"
-            onClick={openEditModal}
-          >
-            Edit dates & guests
-          </Button>
+          {isFestCreator && (
+            <Button
+              variant="link-secondary"
+              className={"ml-5"}
+              size="link"
+              onClick={openEditModal}
+            >
+              Edit dates & guests
+            </Button>
+          )}
         </Sidebar>
       </div>
-      {currentUser.id === festQuery.data.fest.creator.id ? (
+      {isFestCreator ? (
         <div>
           <Button
             type="button"


### PR DESCRIPTION
## Describe your changes
A quick fix so that invitees of a fest, can no longer see the button **Edit dates and guests**.

## Issue ticket number and link
slop-77
https://tripleten-apiary.atlassian.net/jira/software/projects/SLOP/boards/2?selectedIssue=SLOP-77

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] If there are changes to components, I have added / updated automated tests
- [ ] I have made any necessary updates to Storybook to accompany these changes
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
