### PR TITLE
Fix / Slop-74 / Remove draft links from drafts page

### DIFF
--- a/src/routes/blog-route/draft-route.jsx
+++ b/src/routes/blog-route/draft-route.jsx
@@ -13,9 +13,6 @@ export function DraftRoute() {
         </Header>
       </div>
       <div className="z-10 relative float-right -top-10left-3/4 mr-32 mt-10 flex">
-        <Link to={"/draft"} className="underline">
-          Drafts
-        </Link>
         <Link to={"/articles/create"} className="underline ml-5 cursor-pointer">
           + New Entry
         </Link>


### PR DESCRIPTION
## Describe your changes
Title is self-explanatory. Simple removal of the "drafts" link from the drafts page.

## Issue ticket number and link

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] If there are changes to components, I have added / updated automated tests
- [ ] I have made any necessary updates to Storybook to accompany these changes
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
