### PR TITLE
feature/slop-79/Protect routes that require a specific user(s)

### DIFF
--- a/src/components/id-protected-route.jsx
+++ b/src/components/id-protected-route.jsx
@@ -1,0 +1,27 @@
+import { useQuery } from "@apollo/client";
+import { Navigate } from "react-router-dom";
+import { GET_USER_AUTHENTICATION } from "../graphql";
+import { Loading } from "./loading";
+
+export function IdProtectedRoute({
+  allowedUserIdsLoading = false,
+  allowedUserIds = [],
+  children,
+}) {
+  const {
+    data,
+    loading: isUserLoading,
+    error,
+  } = useQuery(GET_USER_AUTHENTICATION);
+  const hasPermission = allowedUserIds.includes(data.authenticatedItem.id);
+
+  if (isUserLoading || allowedUserIdsLoading) {
+    return <Loading />;
+  }
+
+  if (error || !data?.authenticatedItem || !hasPermission) {
+    return <Navigate to="/" replace />;
+  }
+
+  return children;
+}

--- a/src/page/blog/article-page.jsx
+++ b/src/page/blog/article-page.jsx
@@ -5,6 +5,7 @@ import { useNavigate, useParams } from "react-router";
 import { ToastContainer } from "react-toastify";
 import { Form } from "../../../src/components/form";
 import { Button } from "../../components/button";
+import { IdProtectedRoute } from "../../components/id-protected-route.jsx";
 import { Footer } from "../../components/index.js";
 import {
   CREATE_POST,
@@ -21,13 +22,14 @@ export const Article = ({ type }) => {
   const [successful, setSuccessful] = useState(false);
   const [createPost, { loading, error }] = useMutation(CREATE_POST);
   const { currentUser } = useCurrentUser();
-  const { data } = useQuery(GET_BLOG_POST, {
+  const { data, loading: loadingBlog } = useQuery(GET_BLOG_POST, {
     variables: {
       where: {
         id: id,
       },
     },
   });
+  console.log({ data });
   const [deletePost, {}] = useMutation(DELETE_POST, {
     // delete blog post from cache
     update(cache, {}) {
@@ -200,18 +202,10 @@ export const Article = ({ type }) => {
     }
   };
 
-  return (
+  const articleJsx = (
     <>
       {!successful ? (
         <div className="relative flex flex-row justify-center mx-auto -top-5 pt-20">
-          {type === "edited" && (
-            <button
-              onClick={onDelete}
-              className=" absolute top-10 right-10 bg-transparent text-danger font-bold text-lg mt-10"
-            >
-              Delete
-            </button>
-          )}
           <ToastContainer className={"absolute"} />
           <Form className={"w-[700px] ml-[224px] p-5 bg-white"}>
             <Form.TextInput
@@ -338,6 +332,18 @@ Would conditionally adding these CSS styles be the best approach, or does the fo
       </div>
     </>
   );
+  if (type === "new") {
+    return articleJsx;
+  } else {
+    return (
+      <IdProtectedRoute
+        allowedUserIdsLoading={loadingBlog}
+        allowedUserIds={[data?.post?.author?.id]}
+      >
+        {articleJsx}
+      </IdProtectedRoute>
+    );
+  }
 };
 
 export default Article;

--- a/src/routes/fest-route/fest-discussion.jsx
+++ b/src/routes/fest-route/fest-discussion.jsx
@@ -2,6 +2,7 @@ import { useMutation, useQuery } from "@apollo/client";
 import { useState } from "react";
 import { useParams } from "react-router";
 import { Button, DiscussionCard, Header, Loading } from "../../components";
+import { IdProtectedRoute } from "../../components/id-protected-route.jsx";
 import {
   CREATE_DISCUSSION,
   GET_DISCUSSIONS,
@@ -26,6 +27,12 @@ export const FestDiscussion = ({}) => {
   const attendeesList = festQuery?.data?.fest?.attendees?.map(
     (person) => person?.id
   );
+  // Create an array of all invitees to later check if the current user is in list
+  const inviteesList = festQuery?.data?.fest?.invitees?.map(
+    (person) => person?.id
+  );
+  // attendees + invitees
+  const allowedUserIds = attendeesList?.concat(inviteesList);
 
   // Discussion Query to pull all discussions from server
   const discussionQuery = useQuery(GET_DISCUSSIONS, {
@@ -62,7 +69,10 @@ export const FestDiscussion = ({}) => {
   }
 
   return (
-    <>
+    <IdProtectedRoute
+      allowedUserIds={allowedUserIds}
+      allowedUserIdsLoading={festQuery.loading}
+    >
       <Header>
         <Header.Logo />
         <Header.NavLinks />
@@ -134,6 +144,6 @@ export const FestDiscussion = ({}) => {
           </div>
         </div>
       </div>
-    </>
+    </IdProtectedRoute>
   );
 };

--- a/src/routes/fest-route/fest-route.jsx
+++ b/src/routes/fest-route/fest-route.jsx
@@ -2,20 +2,32 @@ import { useMutation, useQuery } from "@apollo/client";
 import { useMemo } from "react";
 import { useParams } from "react-router";
 import { Button, Header, Loading, MovieCardList } from "../../components";
+import { IdProtectedRoute } from "../../components/id-protected-route";
 import { GET_FEST, GET_MOVIES } from "../../graphql/";
 import { UPDATE_FEST } from "../../graphql/mutations/fest";
-import { useModals } from "../../hooks";
+import { useCurrentUser, useModals } from "../../hooks";
 import magGlassDark from "../../images/mag-glass-black.svg";
 import { FestHeader, FestModal, FestSidebar } from "../fest-route";
 
 export const FestRoute = () => {
   const { festId } = useParams();
   const { openModal, closeModal } = useModals();
+  const { currentUser } = useCurrentUser();
 
   // Fest Query to pull fests from server
   const festQuery = useQuery(GET_FEST, {
     variables: { where: { id: festId } },
   });
+  // an array of all attendees id's
+  const attendeeIds = festQuery?.data?.fest?.attendees.map(
+    (attendee) => attendee.id
+  );
+  // an array of all invitees id's
+  const inviteeIds = festQuery?.data?.fest?.invitees.map(
+    (attendee) => attendee.id
+  );
+  // attendees + invitees
+  const allowedUserIds = attendeeIds?.concat(inviteeIds);
 
   // Movie Query
   const moviesQuery = useQuery(GET_MOVIES, { variables: { where: {} } });
@@ -78,7 +90,10 @@ export const FestRoute = () => {
   }
 
   return (
-    <>
+    <IdProtectedRoute
+      allowedUserIds={allowedUserIds}
+      allowedUserIdsLoading={festQuery.loading}
+    >
       <Header>
         <Header.Logo />
         <Header.NavLinks />
@@ -152,6 +167,6 @@ export const FestRoute = () => {
           </div>
         </div>
       </div>
-    </>
+    </IdProtectedRoute>
   );
 };


### PR DESCRIPTION
## Describe your changes
Protect 3 routes: "/articles/:id/edit" , "/fests/:festId" , "/fests/:festId/discussion". 
The route "/articles/:id/edit", should only be viewable by the article author.
The routes "/fests/:festId" and "/fests/:festId/discussion", should only be viewable by the fest creator (who is naturally an invitee to their own fest) and any other invitees/attendees. 

**Testing:**
In order to test this, I recommend copying the url on one of these routes, when logged in as an authorized user. And then logging in to a user that shouldn't have access, and pasting the url into the browser. If unauthorized, you should be redirected to the home page.

**Note** that if you create a fest in the Keystone UI, the user that you make the creator of the fest, is not automatically made an invitee or attendee. Therefore, if you decide to create a fest in the Keystone UI, please also add the creator of the fest as an invitee. If you create the fest within the actual application, then the creator is automatically added an invitee of their own fest.

## Issue ticket number and link
slop-79
https://tripleten-apiary.atlassian.net/jira/software/projects/SLOP/boards/2?selectedIssue=SLOP-79

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] If there are changes to components, I have added / updated automated tests
- [ ] I have made any necessary updates to Storybook to accompany these changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
