### PR TITLE
Fix/slop-82/Redirect User After Creating a Draft Blog Post

### DIFF
--- a/src/page/blog/article-page.jsx
+++ b/src/page/blog/article-page.jsx
@@ -141,7 +141,13 @@ export const Article = ({ type }) => {
           },
         },
       })
-        .then(() => onSuccessful())
+        .then(() => {
+          if (status === "published") {
+            onSuccessful();
+          } else {
+            router("/draft");
+          }
+        })
         .catch((err) => {
           console.error(err, "Could not create blog.");
         });


### PR DESCRIPTION
## Describe your changes
A quick fix, so that now when a user creates a new draft blog, instead of showing the success page, it now redirects the user to the drafts page.

## Issue ticket number and link
slop-82
https://tripleten-apiary.atlassian.net/jira/software/projects/SLOP/boards/2?selectedIssue=SLOP-82

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] If there are changes to components, I have added / updated automated tests
- [ ] I have made any necessary updates to Storybook to accompany these changes
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
