### PR TITLE
Fix/slop-88/sidebar active links

### DIFF
--- a/src/components/sidebar/sidebar-item.jsx
+++ b/src/components/sidebar/sidebar-item.jsx
@@ -1,12 +1,24 @@
 import cx from "classnames";
-import { Link } from "react-router-dom";
+import { NavLink } from "react-router-dom";
 
-export const SidebarItem = ({ link, title, className }) => {
+export const SidebarItem = ({ item, className }) => {
   return (
-    <Link to={link} className={cx("gap-5 ml-5", className)}>
-      <span className="hover:border-b-[3px] hover:border-black hover:text-black text-gray-500 text-lg font-arialBold">
-        {title}
-      </span>
-    </Link>
+    <NavLink
+      to={item.link}
+      end
+      className={({ isActive }) =>
+        cx(
+          "flex gap-5 text-lg font-arialBold decoration-solid decoration-2 hover:underline hover:opacity-100",
+          className,
+          {
+            "underline opacity-100 ": isActive,
+            "opacity-60": !isActive,
+          }
+        )
+      }
+    >
+      <img className="h-8 w-8 " src={item.src} alt={item.title} />
+      {item.title}
+    </NavLink>
   );
 };

--- a/src/routes/profile-route/profile-sidebar.jsx
+++ b/src/routes/profile-route/profile-sidebar.jsx
@@ -52,26 +52,24 @@ export const ProfileSidebar = () => {
           {menuItems.map((item, index) => {
             return (
               <div key={index} className="flex  ">
-                <img className="h-8 w-8 " src={item.src} alt={item.title} />
                 <div className="mt-1">
-                  <Sidebar.Item link={item.link} title={item.title} />
+                  <Sidebar.Item item={item} />
                 </div>
               </div>
             );
           })}
-          <div className="flex">
+
+          <button
+            onClick={handleLogout}
+            className="flex gap-5 font-arialBold text-lg hover:underline decoration-solid decoration-2 hover:opacity-100 opacity-60"
+          >
             <img
               src="/src/images/sidebar-arrow.svg"
               alt="sidebar arrow"
               className="h-8 w-8"
             ></img>
-
-            <button onClick={handleLogout} className="gap-5 ml-5">
-              <span className="font-arialBold text-lg hover:border-b-[3px] hover:border-black">
-                Logout
-              </span>
-            </button>
-          </div>
+            Logout
+          </button>
         </Sidebar>
       </div>
     </div>


### PR DESCRIPTION
## Describe your changes
The sidebar links of the profile page match the design and Figma and have an active state 
![image](https://github.com/jahorwitz/slopopedia/assets/70713202/b049261f-a2ef-4fa9-9641-d38c865b1bf2)

## Issue ticket number and link
Slop-88

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] If there are changes to components, I have added / updated automated tests
- [ ] I have made any necessary updates to Storybook to accompany these changes
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
