### PR TITLE
Fix / Slop-87 / Preview Slop Modal Should not Allow Watched It/Want It Buttons

### DIFF
--- a/src/components/movie-preview-modal.jsx
+++ b/src/components/movie-preview-modal.jsx
@@ -176,8 +176,6 @@ export const MoviePreviewModal = ({
     howToWatch: selectedMovie.howToWatch,
   };
 
-  console.log(selectedMovie);
-
   return (
     <Modal whiteButton={whiteButton}>
       <BlurredImage image={movie.photo}>

--- a/src/components/movie-preview-modal.jsx
+++ b/src/components/movie-preview-modal.jsx
@@ -176,7 +176,7 @@ export const MoviePreviewModal = ({
     howToWatch: selectedMovie.howToWatch,
   };
 
-console.log(selectedMovie)
+  console.log(selectedMovie);
 
   return (
     <Modal whiteButton={whiteButton}>

--- a/src/components/movie-preview-modal.jsx
+++ b/src/components/movie-preview-modal.jsx
@@ -176,7 +176,7 @@ export const MoviePreviewModal = ({
     howToWatch: selectedMovie.howToWatch,
   };
 
-  console.log(selectedMovie);
+console.log(selectedMovie)
 
   return (
     <Modal whiteButton={whiteButton}>

--- a/src/components/movie-preview-modal.jsx
+++ b/src/components/movie-preview-modal.jsx
@@ -176,6 +176,8 @@ export const MoviePreviewModal = ({
     howToWatch: selectedMovie.howToWatch,
   };
 
+  console.log(selectedMovie);
+
   return (
     <Modal whiteButton={whiteButton}>
       <BlurredImage image={movie.photo}>
@@ -226,7 +228,7 @@ export const MoviePreviewModal = ({
         )}
 
         {/* userButtons */}
-        {userButtons && (
+        {userButtons && selectedMovie.status === "published" && (
           <div className="flex gap-x-5 mt-10 font-bold text-lg/4">
             <Button
               variant={isWatchedClicked ? "primary" : "outline-secondary"}


### PR DESCRIPTION
## Describe your changes
Add conditional rendering to userButtons in movie-preview-modal based on slop status

## Issue ticket number and link
https://tripleten-apiary.atlassian.net/browse/SLOP-87?atlOrigin=eyJpIjoiN2FjZjAzMjQwNmYxNDMyMGI1NjM5OWQ4MTEwMzAxNGEiLCJwIjoiaiJ9

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] If there are changes to components, I have added / updated automated tests
- [ ] I have made any necessary updates to Storybook to accompany these changes
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
