### PR TITLE
Fix / Slop 89 / Don't reload whole page when viewing profile

### DIFF
--- a/src/components/header/header.jsx
+++ b/src/components/header/header.jsx
@@ -300,9 +300,9 @@ Header.Profile = ({
         </div>
       ) : (
         <div className="flex flex-row h-[24px] gap-2.5 md:gap-1 md:pl-4 md:flex lg:flex xl:flex sm:hidden xs:hidden">
-          <a href="/profile" className="border-b-2">
+          <Link to="/profile" className="border-b-2">
             {currentUser.username}
-          </a>
+          </Link>
           <img className="w-6 h-6 mt-0.5" src={headerSmile} />
         </div>
       )}


### PR DESCRIPTION
## Describe your changes
Utilize react-router-dom "Link" component to avoid refreshing the page when the profile page is selected.

## Issue ticket number and link
https://tripleten-apiary.atlassian.net/browse/SLOP-89?atlOrigin=eyJpIjoiNjcwZWM4NTNhODEzNDM4NGJlNWE5MWM3OGQ4MGE3MjEiLCJwIjoiaiJ9

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] If there are changes to components, I have added / updated automated tests
- [ ] I have made any necessary updates to Storybook to accompany these changes
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
