### PR TITLE
Fix/slop 106/image styling

### DIFF
--- a/src/components/movie-card-list.jsx
+++ b/src/components/movie-card-list.jsx
@@ -11,7 +11,7 @@ export const MovieCardList = ({
 }) => {
   return (
     <>
-      <div className="grid grid-cols-5 md:grid-cols-5 sm:grid-cols-4 xs:grid-cols-3 gap-5">
+      <div className="grid gap-y-5 gap-x-2.5 xl:grid-cols-5 lg:grid-cols-4 md:grid-cols-4 sm:grid-cols-3 xs:grid-cols-3 gap-5 mx-auto">
         {movies?.map((movie) => (
           <MovieCard
             key={movie.id}

--- a/src/components/movie-card-list.jsx
+++ b/src/components/movie-card-list.jsx
@@ -11,7 +11,7 @@ export const MovieCardList = ({
 }) => {
   return (
     <>
-      <div className="grid gap-y-5 gap-x-2.5 xl:grid-cols-5 lg:grid-cols-4 md:grid-cols-4 sm:grid-cols-3 xs:grid-cols-3 gap-5 mx-auto">
+      <div className="grid gap-y-5 gap-x-2.5 xl:grid-cols-5 lg:grid-cols-4 md:grid-cols-4 sm:grid-cols-3 xs:grid-cols-3 gap-5">
         {movies?.map((movie) => (
           <MovieCard
             key={movie.id}

--- a/src/components/movie-card/movie-card.jsx
+++ b/src/components/movie-card/movie-card.jsx
@@ -37,7 +37,7 @@ export function MovieCard({
     description: movieInfo?.description,
   };
 
-  // Functionality for opening movie preview modal
+  // functionality for opening movie preview modal
   const { closeModal, openModal } = useModals();
   const [columnSpan, setColumnSpan] = useState(null);
 
@@ -52,13 +52,13 @@ export function MovieCard({
     );
   };
 
-  // This provides random values to each movie size once on render for main route
+  // this provides random values to each movie size once on render for main route
   useEffect(() => {
     const randomColumnValue = getRandomColumns();
     setColumnSpan(randomColumnValue);
   }, []);
 
-  // Sets the size of the container for image and subsection text
+  // sets the size of the container for image and subsection text
   const getContainerStyle = () => {
     switch (size) {
       case 1:
@@ -72,7 +72,7 @@ export function MovieCard({
     }
   };
 
-  // Sets the max sizes of the images
+  // sets the max sizes of the images
   const getImageStyle = () => {
     switch (size) {
       case 1:
@@ -86,32 +86,32 @@ export function MovieCard({
     }
   };
 
-  // Sets the classes for the card type being rendered
+  // sets the classes for the card type being rendered
   const cardClasses = cx(
     "flex flex-col relative overflow-hidden",
     colSpanOne ? "col-span-1" : colSpanClass
   );
 
-  // Ensures image covers the container
+  // ensures image covers the container
   const imageClasses = cx(
     "w-full object-cover ",
     containerSize === "small" &&
       "object-contain h-[120px] self-baseline xs:self-center"
   );
 
-  // Sets style for titles of movies
+  // sets style for titles of movies
   const titleClasses = cx(
     "text-lg font-bold font-arial leading-none hover:cursor-pointer",
     size === 1 && "mb-2.5 mt-2.5"
   );
 
-  // Sets style for the runtime of movies
+  // sets style for the runtime of movies
   const runtimeClasses = cx(
     "text-lg font-arial leading-none text-dark opacity-60 hover:cursor-pointer",
     size === 1 && "mb-2.5"
   );
 
-  // Renders the html for the runtime, title, and year text
+  // renders the html for the runtime, title, and year text
   const renderTitleAndRuntime = () => (
     <>
       <h2
@@ -200,7 +200,7 @@ export function MovieCard({
         )}
         {card.keywords && (
           <div
-            // Keywords are positioned absolutely on the image of the card if the size is equal or equal to two
+            // keywords are positioned absolutely on the image of the card if the size is equal or equal to two
             className={
               "flex flex-wrap gap-2 " +
               (size === 1

--- a/src/components/movie-card/movie-card.jsx
+++ b/src/components/movie-card/movie-card.jsx
@@ -58,7 +58,6 @@ export function MovieCard({
     setColumnSpan(randomColumnValue);
   }, []);
 
-
   // sets the max sizes of the images
   const getImageStyle = () => {
     switch (size) {
@@ -137,9 +136,7 @@ export function MovieCard({
 
   return (
     <div
-     
       className={colSpanOne ? "col-span-1" : colSpanClass}
-    
       data-test-id={`moviecard-wrapper-div${
         card.title ? "-" + card.title : ""
       }`}
@@ -174,7 +171,7 @@ export function MovieCard({
         <div style={{ width: "100%", height: getImageStyle().maxHeight }}>
           <img
             data-test-id="moviecard-openmodal-img"
-          className={imageClasses}
+            className={imageClasses}
             src={!card.image ? purpleGoblin : card.image?.url}
             style={{ height: "100%" }}
             onClick={() => handleMovieClick()}

--- a/src/components/movie-card/movie-card.jsx
+++ b/src/components/movie-card/movie-card.jsx
@@ -37,7 +37,7 @@ export function MovieCard({
     description: movieInfo?.description,
   };
 
-  //functionality for opening movie preview modal
+  // Functionality for opening movie preview modal
   const { closeModal, openModal } = useModals();
   const [columnSpan, setColumnSpan] = useState(null);
 
@@ -52,23 +52,114 @@ export function MovieCard({
     );
   };
 
-  //this provides random values to each movie size once on render for main route
+  // This provides random values to each movie size once on render for main route
   useEffect(() => {
     const randomColumnValue = getRandomColumns();
     setColumnSpan(randomColumnValue);
   }, []);
 
+  // Sets the size of the container for image and subsection text
+  const getContainerStyle = () => {
+    switch (size) {
+      case 1:
+        return { maxWidth: "224px", maxHeight: "324px" };
+      case 2:
+        return { maxWidth: "468px", maxHeight: "694px" };
+      case 3:
+        return { maxWidth: "712px", maxHeight: "545px" };
+      default:
+        return {};
+    }
+  };
+
+  // Sets the max sizes of the images
+  const getImageStyle = () => {
+    switch (size) {
+      case 1:
+        return { maxHeight: "190px" };
+      case 2:
+        return { maxHeight: "665px" };
+      case 3:
+        return { maxHeight: "518px" };
+      default:
+        return {};
+    }
+  };
+
+  // Sets the classes for the card type being rendered
+  const cardClasses = cx(
+    "flex flex-col relative overflow-hidden",
+    colSpanOne ? "col-span-1" : colSpanClass
+  );
+
+  // Ensures image covers the container
+  const imageClasses = cx(
+    "w-full object-cover ",
+    containerSize === "small" &&
+      "object-contain h-[120px] self-baseline xs:self-center"
+  );
+
+  // Sets style for titles of movies
+  const titleClasses = cx(
+    "text-lg font-bold font-arial leading-none hover:cursor-pointer",
+    size === 1 && "mb-2.5 mt-2.5"
+  );
+
+  // Sets style for the runtime of movies
+  const runtimeClasses = cx(
+    "text-lg font-arial leading-none text-dark opacity-60 hover:cursor-pointer",
+    size === 1 && "mb-2.5"
+  );
+
+  // Renders the html for the runtime, title, and year text
+  const renderTitleAndRuntime = () => (
+    <>
+      <h2
+        className={titleClasses}
+        onClick={() => handleMovieClick()}
+        style={{
+          fontFamily: "Arial",
+          fontSize: "18px",
+          fontWeight: 700,
+          lineHeight: "16.74px",
+          letterSpacing: "-0.01em",
+          textAlign: "left",
+        }}
+      >
+        {card.title}
+      </h2>
+      {card.runtimeInMinutes && (
+        <p
+          className={runtimeClasses}
+          onClick={() => handleMovieClick()}
+          style={{
+            fontFamily: "Arial",
+            fontSize: "18px",
+            fontWeight: 400,
+            lineHeight: "16.74px",
+            letterSpacing: "-0.01em",
+            textAlign: size >= 2 ? "right" : "left",
+          }}
+        >
+          {card.releaseYear}, {card.runtimeInMinutes}
+          {size === 1 ? " minutes" : ""}
+        </p>
+      )}
+    </>
+  );
+
   return (
-    <div className={colSpanOne ? "col-span-1" : colSpanClass}>
+    <div
+      className={colSpanOne ? "col-span-1" : colSpanClass}
+      style={getContainerStyle()}
+    >
       <div
-        // Parent div is relative to allow for elements and children to be positioned absolutely
-        className={cx(
-          "flex flex-col relative",
-          size === 1 && "col-span-1",
-          size === 2 && "col-span-2",
-          size === 3 && "col-span-3"
-        )}
-        style={{ position: "relative" }}
+        className={cardClasses}
+        style={{
+          width: "100%",
+          height: "100%",
+          position: "relative",
+        }}
         onClick={onClick}
         {...rest}
       >
@@ -88,45 +179,24 @@ export function MovieCard({
             }}
           />
         )}
-        <img
-          className={cx(
-            "mb-2.5 max-h-[80vh] overflow-hidden hover:cursor-pointer",
-            containerSize === "small" &&
-              "object-contain h-[120px] self-baseline xs:self-center"
-          )}
-          src={!card.image ? purpleGoblin : card.image?.url}
-          onClick={() => handleMovieClick()}
-        />
-        {/* title and year + runtime are beside each other if the size is equal or greater than two */}
+        <div style={{ width: "100%", height: getImageStyle().maxHeight }}>
+          <img
+            className={imageClasses}
+            src={!card.image ? purpleGoblin : card.image?.url}
+            style={{ height: "100%" }}
+            onClick={() => handleMovieClick()}
+          />
+        </div>
         {size >= 2 ? (
           <div
-            className="flex flex-row col-span-2 justify-between hover:cursor-pointer"
+            className="flex flex-row col-span-2 justify-between hover:cursor-pointer mt-2.5"
+            style={{ width: "100%" }}
             onClick={() => handleMovieClick()}
           >
-            <h2 className="text-lg mb-2.5 font-bold font-arial">
-              {card.title}
-            </h2>
-            <p className="text-lg mb-2.5 text-gray-400 font-arial">
-              {card.releaseYear}, {card.runtimeInMinutes}
-            </p>
+            {renderTitleAndRuntime()}
           </div>
         ) : (
-          <>
-            <h2
-              className="text-lg mb-2.5 font-bold font-arial leading-none hover:cursor-pointer"
-              onClick={() => handleMovieClick()}
-            >
-              {card.title}
-            </h2>
-            {card.runtimeInMinutes && (
-              <p
-                className="text-lg mb-2.5 font-arial leading-none text-dark opacity-60 hover:cursor-pointer"
-                onClick={() => handleMovieClick()}
-              >
-                {card.releaseYear}, {card.runtimeInMinutes} minutes
-              </p>
-            )}
-          </>
+          renderTitleAndRuntime()
         )}
         {card.keywords && (
           <div

--- a/src/components/movie-card/movie-card.jsx
+++ b/src/components/movie-card/movie-card.jsx
@@ -58,19 +58,6 @@ export function MovieCard({
     setColumnSpan(randomColumnValue);
   }, []);
 
-  // sets the size of the container for image and subsection text
-  const getContainerStyle = () => {
-    switch (size) {
-      case 1:
-        return { maxWidth: "224px", maxHeight: "324px" };
-      case 2:
-        return { maxWidth: "468px", maxHeight: "694px" };
-      case 3:
-        return { maxWidth: "712px", maxHeight: "545px" };
-      default:
-        return {};
-    }
-  };
 
   // sets the max sizes of the images
   const getImageStyle = () => {

--- a/src/components/movie-card/movie-card.jsx
+++ b/src/components/movie-card/movie-card.jsx
@@ -151,7 +151,6 @@ export function MovieCard({
   return (
     <div
       className={colSpanOne ? "col-span-1" : colSpanClass}
-      style={getContainerStyle()}
     >
       <div
         className={cardClasses}


### PR DESCRIPTION
## Describe your changes

- Added styling to the movie cards to match the Figma design on the homepage. 
- Altered grid system to adjust for smaller screens - needs further work I believe perhaps in a future ticket.

Figma Design: https://www.figma.com/design/NDxE2DhULzua1KRFG6d4hA/Slopopedia?node-id=248-10750&t=HsHmTalBRM0JAnUx-0

## Issue ticket number and link

Slop-106: https://tripleten-apiary.atlassian.net/browse/SLOP-106?atlOrigin=eyJpIjoiNDY1NTY0NjY3MTQ2NGJiOWJkNDU2ZGMxZDdhNGE4N2MiLCJwIjoiaiJ9

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] If there are changes to components, I have added / updated automated tests
- [ ] I have made any necessary updates to Storybook to accompany these changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
