### PR TITLE
fix: the edit modal when opened will have newly created movie without having to refresh page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -21,6 +21,7 @@ import {
   SubmitRoute,
   SubmittedSlopsRoute,
 } from "./routes";
+import { EditSlop } from "./routes/slop-route/edit-submitted-slop-route";
 import { CurrentUserContextProvider, ModalContextProvider } from "./store";
 import { MovieContextProvider } from "./store/movie-context-provider";
 import { SoundContextProvider } from "./store/sound-context-provider";
@@ -101,6 +102,14 @@ export const App = () => {
                     element={
                       <ProtectedRoute>
                         <SubmittedSlopsRoute />
+                      </ProtectedRoute>
+                    }
+                  />
+                  <Route // added this for the route to work to navigate to edit the slop
+                    path="/edit-slop/:slopId" //do not know if this route name is ok but will check
+                    element={
+                      <ProtectedRoute>
+                        <EditSlop />
                       </ProtectedRoute>
                     }
                   />

--- a/src/graphql/create-movie.js
+++ b/src/graphql/create-movie.js
@@ -1,24 +1,51 @@
 import { gql } from "@apollo/client";
+// export const CREATE_MOVIE = gql`
+//   mutation Mutation($data: MovieCreateInput!) {
+//     createMovie(data: $data) {
+//       author {
+//         id
+//         username
+//       }
+//       title
+//       description
+//       releaseYear
+//       runtime
+//       id
+//       keywords {
+//         name
+//       }
+//       tomatoScore
+//       photo {
+//         url
+//       }
+//       howToWatch
+//     }
+//   }
+// `;
+
 export const CREATE_MOVIE = gql`
   mutation Mutation($data: MovieCreateInput!) {
     createMovie(data: $data) {
-      author {
-        id
-        username
-      }
-      title
-      description
-      releaseYear
-      runtime
       id
+      title
+      runtime
+      releaseYear
       keywords {
+        id
         name
       }
+      description
       tomatoScore
       photo {
         url
       }
       howToWatch
+      author {
+        id
+        isAdmin
+        username
+      }
+      status
     }
   }
 `;

--- a/src/routes/slop-route/edit-submitted-slop-route.jsx
+++ b/src/routes/slop-route/edit-submitted-slop-route.jsx
@@ -1,5 +1,6 @@
 import { useMutation, useQuery } from "@apollo/client";
 import { useEffect, useState } from "react";
+import { useForm } from "react-hook-form"; // kept getting uncaught error for 'watch' on Form.Combobox
 import { useNavigate, useParams } from "react-router-dom";
 import { Form } from "../../components/form/form";
 import { Header } from "../../components/header/header";
@@ -9,6 +10,7 @@ import { GET_MOVIE } from "../../graphql/queries/get-movie-by-id";
 export const EditSlop = () => {
   const { slopId } = useParams();
   const navigate = useNavigate();
+  const { watch } = useForm(); // added this to get rid of the uncaught error i kept getting for 'watch'
 
   //set slopData to be empty as that was causing my form to error when loading
   const [slopData, setSlopData] = useState({
@@ -40,6 +42,7 @@ export const EditSlop = () => {
   );
 
   //this use effect hook pulls the movie data and keywords and sets them into the edit form.
+
   useEffect(() => {
     if (data && data.movie) {
       setSlopData(data.movie);
@@ -84,7 +87,7 @@ export const EditSlop = () => {
           data: updatedMovieData,
         },
       });
-      navigate("/submit-list");
+      navigate("/submitted-list"); //updatted this from "submit-list" to "submitted-list"
     } catch (e) {
       console.error("Error updating movie", e);
     }
@@ -149,6 +152,7 @@ export const EditSlop = () => {
             onSelectionChange={handleKeywordChange}
             nameKey="name"
             idKey="name"
+            watch={watch} // added this to get rid of error it was causing
           />
           <Form.Submit title="Save Changes" />
         </form>

--- a/src/routes/submit-route/submitted-slops/submitted-list.jsx
+++ b/src/routes/submit-route/submitted-slops/submitted-list.jsx
@@ -1,4 +1,5 @@
 import { useQuery } from "@apollo/client";
+import { useNavigate } from "react-router-dom"; // added this
 import {
   Button,
   DeleteMovieModal,
@@ -13,6 +14,8 @@ import deleteIcon from "../../../images/red-x-button.svg";
 
 export const SubmittedList = ({ currentUser }) => {
   const { openModal, closeModal } = useModals();
+
+  const navigate = useNavigate(); // added this
 
   // Determine the data query based on the user's admin status
   const queryVariables =
@@ -63,7 +66,10 @@ export const SubmittedList = ({ currentUser }) => {
     );
   }
 
-  console.log("this is me hahahahah", data);
+  //this is where i am adding function for the editing part of the process
+  function handleEditClick(slopId) {
+    navigate(`/edit-slop/${slopId}`); // needed this function to be able to navigate to the correct route
+  }
 
   return (
     <div className="w-fit h-fit">
@@ -83,7 +89,11 @@ export const SubmittedList = ({ currentUser }) => {
                 <Button
                   variant="outline-secondary"
                   className="text-lg font-bold flex gap-2.5 h-10 w-51 w-full"
-                  onClick={() => handleApproveClick(movie)}
+                  onClick={
+                    currentUser.isAdmin
+                      ? () => handleApproveClick(movie)
+                      : () => handleEditClick(movie.id) // added this so that edit click works if current user is not admin
+                  }
                 >
                   <img src={currentUser.isAdmin ? checkIcon : pencilIcon} />
                   {currentUser.isAdmin ? "Accept & Publish" : "Edit"}

--- a/src/routes/submit-route/submitted-slops/submitted-list.jsx
+++ b/src/routes/submit-route/submitted-slops/submitted-list.jsx
@@ -63,6 +63,8 @@ export const SubmittedList = ({ currentUser }) => {
     );
   }
 
+  console.log("this is me hahahahah", data);
+
   return (
     <div className="w-fit h-fit">
       {!loading && (


### PR DESCRIPTION
… having to refresh

## Describe your changes
*changed the submit-slop-form.jsx when initializing createMovie and using the mutation from query it adds the newly created movie to the cache allowing it to be on the edit page
*also had to switch up the CREATE_MOVIE 'gql' mutation to fix some of the errors 
## Issue ticket number and link
slop-30
https://tripleten-apiary.atlassian.net/jira/software/projects/SLOP/boards/2?selectedIssue=SLOP-30

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] If there are changes to components, I have added / updated automated tests
- [ ] I have made any necessary updates to Storybook to accompany these changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
