### PR TITLE
Fix/slop 122 & slop 127/blog article short preview/intersecting footer fix

### DIFF
--- a/src/components/blog/post.jsx
+++ b/src/components/blog/post.jsx
@@ -26,7 +26,6 @@ export const Post = ({
   });
   return (
     <div className={`${className} w-96 max-h-50`}>
-      {/* ^ setting max height to the parent post container */}
       <h2
         onClick={() => router(`/articles/${id}`)}
         className="font-semibold text-2xl tracking-tighter mb-4 cursor-pointer"

--- a/src/components/blog/post.jsx
+++ b/src/components/blog/post.jsx
@@ -25,7 +25,8 @@ export const Post = ({
     );
   });
   return (
-    <div className={`${className} w-96`}>
+    <div className={`${className} w-96 max-h-50`}>
+      {/* ^ setting max height to the parent post container */}
       <h2
         onClick={() => router(`/articles/${id}`)}
         className="font-semibold text-2xl tracking-tighter mb-4 cursor-pointer"
@@ -33,8 +34,10 @@ export const Post = ({
         {title}
       </h2>
       {keywordsList}
-      <p className="break-word text-sm font-normal mb-4">{content}</p>
-      <div className="flex justify-between">
+      <p className="break-word text-sm font-normal mb-4 text-clip h-20 line-clamp-4">
+        {content}
+      </p>
+      <div className="flex justify-between max-h-20">
         {date === null ? (
           <small>"no published date"</small>
         ) : (

--- a/src/components/footer/footer.jsx
+++ b/src/components/footer/footer.jsx
@@ -1,6 +1,7 @@
 export const Footer = () => {
   return (
-    <footer className="flex flex-row gap-10 justify-between max-w-[989px]  mx-auto xs:flex-col xs:ml-5 sm:ml-5  sm:flex-col">
+    <footer className="flex flex-row gap-10 justify-between max-w-[989px]  mx-auto xs:flex-col xs:ml-5 sm:ml-5">
+      {/* ^ letting only the footer become a column at the extra small screen sizes to prevent clipping */}
       <div className="font-arial text-dark/60 text-sm xs:mb-4 sm:mb-4">
         <p className="">2023 The Slop Goblin's Web Reference</p>
       </div>

--- a/src/page/blog/review-page.jsx
+++ b/src/page/blog/review-page.jsx
@@ -159,9 +159,10 @@ export const Review = ({ id }) => {
         </div>
       </div>
       <div
-        className="absolute bottom-0 w-full max-w-[989] mx-auto mt-auto p-10"
+        className="w-full max-w-[989] p-10 mt-auto"
         data-test-id="review-page-footer"
       >
+        {/* ^ removing absolute positioning to footer sits UNDER review page content */}
         <Footer data-test-id="review-page-footer">
           {/* <Footer.Content></Footer.Content>{" "} */}
         </Footer>


### PR DESCRIPTION
## This is a combination of Slop-122 and Slop-127

## Describe your changes

Blog articles page text previews no longer overflow from the parent post container (see screenshots in slop board to compare)
![image_2024-08-02_130737044](https://github.com/user-attachments/assets/7f2a32a0-79df-43de-98ca-91e51c446764)

Blog post review page no longer has clipping footer and sits under the pages content
![image](https://github.com/user-attachments/assets/fac594f4-e8fd-493d-b713-cad9df296bc6)



## Issue ticket number and link
https://tripleten-apiary.atlassian.net/browse/SLOP-122

## Checklist before requesting a review

- [X] I have performed a self-review of my code
- [X] If there are changes to components, I have added / updated automated tests
- [ ] I have made any necessary updates to Storybook to accompany these changes
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
