### PR TITLE
fix: Sign Up input field with max character limit

### DIFF
--- a/src/components/form/form.jsx
+++ b/src/components/form/form.jsx
@@ -82,6 +82,7 @@ Form.TextInput = ({
           register={register}
           defaultValue={prefilledInputs}
           id={id}
+          maxLength="30"
           className={`font-normal bg-background py-3 px-4 border-solid rounded-none border ${
             isValid ? "border-black" : "border-danger focus:outline-danger"
           } ${classNameInput} `}


### PR DESCRIPTION
## Describe your changes
Added a maximum character limit to the input fields of the Sign Up modal

## Issue ticket number and link
Slop-111 [https://tripleten-apiary.atlassian.net/browse/SLOP-111]

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If there are changes to components, I have added / updated automated tests
- [ ] I have made any necessary updates to Storybook to accompany these changes
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
