### PR TITLE
Fix/Runtime and Release Year fields only accept numbers

### DIFF
--- a/src/routes/submit-route/submit-slop-form.jsx
+++ b/src/routes/submit-route/submit-slop-form.jsx
@@ -209,8 +209,12 @@ export const SubmitSlopForm = () => {
               placeholder="Release Year"
               labelText="Release Year *"
               onChange={(e) => {
-                if (!isNaN(e.target.value) && e.target.value !== " ") {
-                  setValue("releaseYear", e.target.value, {
+                const value = e.target.value;
+                if (
+                  value === "" ||
+                  (!isNaN(value) && /^\d+$/.test(value) && value.length <= 3)
+                ) {
+                  setValue("releaseYear", value, {
                     shouldValidate: true,
                   });
                 }
@@ -228,14 +232,19 @@ export const SubmitSlopForm = () => {
               maxLength={3}
               value={runtime}
               errors={errors}
+              type="number"
               register={register("runtime", {
                 required: "Runtime is required",
               })}
               placeholder="Runtime"
               labelText="Runtime *"
               onChange={(e) => {
-                if (!isNaN(e.target.value) && e.target.value !== " ") {
-                  setValue("runtime", e.target.value, { shouldValidate: true });
+                const value = e.target.value;
+                if (
+                  value === "" ||
+                  (!isNaN(value) && /^\d+$/.test(value) && value.length <= 3)
+                ) {
+                  setValue("runtime", value, { shouldValidate: true });
                 }
               }}
               isValid={!errors.runtime}

--- a/src/routes/submit-route/submit-slop-form.jsx
+++ b/src/routes/submit-route/submit-slop-form.jsx
@@ -212,7 +212,10 @@ export const SubmitSlopForm = () => {
                 const value = e.target.value;
                 if (
                   value === "" ||
-                  (!isNaN(value) && /^\d+$/.test(value) && value.length <= 3)
+                  (!isNaN(value) &&
+                    /^\d+$/.test(value) &&
+                    !/^0+$/.test(value) &&
+                    value.length <= 4)
                 ) {
                   setValue("releaseYear", value, {
                     shouldValidate: true,
@@ -242,7 +245,10 @@ export const SubmitSlopForm = () => {
                 const value = e.target.value;
                 if (
                   value === "" ||
-                  (!isNaN(value) && /^\d+$/.test(value) && value.length <= 3)
+                  (!isNaN(value) &&
+                    /^\d+$/.test(value) &&
+                    !/^0+$/.test(value) &&
+                    value.length <= 3)
                 ) {
                   setValue("runtime", value, { shouldValidate: true });
                 }


### PR DESCRIPTION
## Describe your changes
I added two regular expressions to the release date and runtime input fields of the submit slop form to prevent users from entering all zero values, or non-whole numbers

## Issue ticket number and link
Slop-174: [https://tripleten-apiary.atlassian.net/browse/SLOP-174]

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] If there are changes to components, I have added / updated automated tests
- [ ] I have made any necessary updates to Storybook to accompany these changes
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
