### PR TITLE
fix: profile-settings-route.jsx correct data now used in setValue from res in onSubmit

### DIFF
--- a/src/routes/profile-route/profile-settings-route.jsx
+++ b/src/routes/profile-route/profile-settings-route.jsx
@@ -105,8 +105,9 @@ export const ProfileSettingsRoute = () => {
         },
       })
         .then((res) => {
-          setValue("username", res.data.username);
-          setValue("email", res.data.email);
+          console.log(res);
+          setValue("username", res.data.updateUser.username);
+          setValue("email", res.data.updateUser.email);
         })
         .catch(error);
     } else {

--- a/src/routes/profile-route/profile-settings-route.jsx
+++ b/src/routes/profile-route/profile-settings-route.jsx
@@ -121,6 +121,7 @@ export const ProfileSettingsRoute = () => {
           setValue("username", res.data.username);
           setValue("email", res.data.email);
           setValue("password", "");
+          location.reload();
         })
         .catch(error);
     }


### PR DESCRIPTION
## Describe your changes
When onSubmit fired, the returned data in res that was being used to setValue was empty, so when trying to save new user data again, it would say that the field was empty. The correct data is now being used to fill the fields.

## Issue ticket number and link
[242](https://tripleten-apiary.atlassian.net/browse/SLOP-242)
## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] If there are changes to components, I have added / updated automated tests
- [x] I have made any necessary updates to Storybook to accompany these changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
